### PR TITLE
Add 2025 IDETC ideation prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ discrete grammar-style problems behind a small, typed Python API.
 
 - Five problem families: text, decision, optimization, grammar, and MCP, plus a linked ideation metadata catalog.
 - Shared model contracts built around `Problem` and `ComputableProblem`, with family-specific subclasses on top.
-- A seed catalog that includes 40 ideation prompts plus packaged decision, optimization, grammar, and MCP benchmarks.
+- A seed catalog that includes 48 ideation prompts plus packaged decision, optimization, grammar, and MCP benchmarks.
 - Optional integrations for `trussme`, `pybamm`, `mcp`, Build123d, and external solver backends.
 - Typed metadata, a curated public API, runnable examples, and Sphinx docs.
 

--- a/docs/problems/ideation.rst
+++ b/docs/problems/ideation.rst
@@ -22,8 +22,8 @@ Evidence Tiers
 
 The current ideation corpus includes:
 
-- 40 prompt records with usable packaged text,
-- 40 source-specific or derivative variants,
-- 22 prompt families, all of which now point to at least one packaged prompt,
+- 48 prompt records with usable packaged text,
+- 48 source-specific or derivative variants,
+- 30 prompt families, all of which now point to at least one packaged prompt,
 - 6 study summaries, and
 - no stub-only family records.

--- a/src/design_research_problems/_assets/catalog/ideation/dark_hour_safety/wojciechowski_olagoke_ng_wacnik_kramer_2025/problem.toml
+++ b/src/design_research_problems/_assets/catalog/ideation/dark_hour_safety/wojciechowski_olagoke_ng_wacnik_kramer_2025/problem.toml
@@ -1,0 +1,38 @@
+problem_id = "ideation_dark_hour_safety"
+title = "Dark-Hour Safety"
+summary = "A primary-source ideation brief about supporting safety during dark commuting, running, and late-night travel."
+kind = "text"
+statement = '''
+# Dark-Hour Safety
+
+The shorter daylight hours that come with the seasons can increase safety
+concerns for many, including those who walk to commute, runners who exercise
+early in the morning or late at night, and students going home late from the
+library or social events. Design a way to support safety in the dark morning
+and evening hours.
+'''
+capabilities = ["statement-markdown", "citation-backed", "prompt-packet"]
+study_suitability = ["human-subjects-ready", "ideation-friendly"]
+
+[taxonomy]
+formulation = "textual_prompt"
+is_dynamic = false
+orientation = "engineering_practical"
+objective_mode = "qualitative"
+constraint_nature = "embedded-constraints"
+tags = ["text", "human-subjects", "ideation", "safety", "mobility", "public-space"]
+deliverable_type = "concepts"
+timebox_hint_minutes = 10
+participants = "individual"
+evaluation_mode = "idea_generation"
+
+[[citations]]
+key = "wojciechowski_olagoke_ng_wacnik_kramer_2025"
+kind = "inline"
+authors = ["Lauren Wojciechowski", "Uthman Olagoke", "Rowena Ng", "Peter Wacnik", "Julia Kramer"]
+title = "Musical Playlists to Improve the Ideation Environment: An Exploratory Study"
+year = 2025
+venue = "ASME IDETC/CIE 2025, DETC2025-164691"
+formatted_text = "Wojciechowski, Olagoke, Ng, Wacnik, and Kramer (2025). Musical Playlists to Improve the Ideation Environment: An Exploratory Study. ASME IDETC/CIE 2025, DETC2025-164691."
+raw_text = "Wojciechowski, Olagoke, Ng, Wacnik, and Kramer (2025). Musical Playlists to Improve the Ideation Environment: An Exploratory Study. ASME IDETC/CIE 2025, DETC2025-164691."
+provisional = true

--- a/src/design_research_problems/_assets/catalog/ideation/entryway_track_removal/wojciechowski_olagoke_ng_wacnik_kramer_2025/problem.toml
+++ b/src/design_research_problems/_assets/catalog/ideation/entryway_track_removal/wojciechowski_olagoke_ng_wacnik_kramer_2025/problem.toml
@@ -1,0 +1,38 @@
+problem_id = "ideation_entryway_track_removal"
+title = "Entryway Track Removal"
+summary = "A primary-source ideation brief about removing dirt, snow, and water from shoes before people enter a building."
+kind = "text"
+statement = '''
+# Entryway Track Removal
+
+Building entrances often become messy and unsafe due to snow, dirt, and water
+being tracked inside. Floor mats and fans are often used to mitigate the
+issue, but people often do not wipe their feet or use the fans. Design an
+intuitive way to remove tracks in dirt, snow, and water from individuals'
+shoes before they enter into a building.
+'''
+capabilities = ["statement-markdown", "citation-backed", "prompt-packet"]
+study_suitability = ["human-subjects-ready", "ideation-friendly"]
+
+[taxonomy]
+formulation = "textual_prompt"
+is_dynamic = false
+orientation = "engineering_practical"
+objective_mode = "qualitative"
+constraint_nature = "embedded-constraints"
+tags = ["text", "human-subjects", "ideation", "cleaning", "safety", "buildings"]
+deliverable_type = "concepts"
+timebox_hint_minutes = 10
+participants = "individual"
+evaluation_mode = "idea_generation"
+
+[[citations]]
+key = "wojciechowski_olagoke_ng_wacnik_kramer_2025"
+kind = "inline"
+authors = ["Lauren Wojciechowski", "Uthman Olagoke", "Rowena Ng", "Peter Wacnik", "Julia Kramer"]
+title = "Musical Playlists to Improve the Ideation Environment: An Exploratory Study"
+year = 2025
+venue = "ASME IDETC/CIE 2025, DETC2025-164691"
+formatted_text = "Wojciechowski, Olagoke, Ng, Wacnik, and Kramer (2025). Musical Playlists to Improve the Ideation Environment: An Exploratory Study. ASME IDETC/CIE 2025, DETC2025-164691."
+raw_text = "Wojciechowski, Olagoke, Ng, Wacnik, and Kramer (2025). Musical Playlists to Improve the Ideation Environment: An Exploratory Study. ASME IDETC/CIE 2025, DETC2025-164691."
+provisional = true

--- a/src/design_research_problems/_assets/catalog/ideation/forest_fire_detection/bhatt_ammersdorfer_inkermann_2025/problem.toml
+++ b/src/design_research_problems/_assets/catalog/ideation/forest_fire_detection/bhatt_ammersdorfer_inkermann_2025/problem.toml
@@ -1,0 +1,35 @@
+problem_id = "ideation_forest_fire_detection"
+title = "Forest Fire Detection in Local Forests"
+summary = "A primary-source classroom ideation brief about reliably detecting emerging fire in local forests."
+kind = "text"
+statement = '''
+# Forest Fire Detection in Local Forests
+
+There is an increasing need to prevent fire in local forests. We need a
+device to detect upcoming fires in a reliable way.
+'''
+capabilities = ["statement-markdown", "citation-backed", "prompt-packet"]
+study_suitability = ["human-subjects-ready", "ideation-friendly"]
+
+[taxonomy]
+formulation = "textual_prompt"
+is_dynamic = false
+orientation = "engineering_practical"
+objective_mode = "qualitative"
+constraint_nature = "embedded-constraints"
+tags = ["text", "human-subjects", "ideation", "wildfire", "sensing", "environment"]
+deliverable_type = "concepts"
+timebox_hint_minutes = 30
+participants = "team"
+evaluation_mode = "idea_generation"
+
+[[citations]]
+key = "bhatt_ammersdorfer_inkermann_2025"
+kind = "inline"
+authors = ["Apoorv Naresh Bhatt", "Theresa Ammersdorfer", "David Inkermann"]
+title = "Impact of Problem Brief Characteristics and Influencing Factors on Design Outcomes in a Project-Based Engineering Course"
+year = 2025
+venue = "ASME IDETC/CIE 2025, DETC2025-168538"
+formatted_text = "Bhatt, Ammersdorfer, and Inkermann (2025). Impact of Problem Brief Characteristics and Influencing Factors on Design Outcomes in a Project-Based Engineering Course. ASME IDETC/CIE 2025, DETC2025-168538."
+raw_text = "Bhatt, Ammersdorfer, and Inkermann (2025). Impact of Problem Brief Characteristics and Influencing Factors on Design Outcomes in a Project-Based Engineering Course. ASME IDETC/CIE 2025, DETC2025-168538."
+provisional = true

--- a/src/design_research_problems/_assets/catalog/ideation/household_moving/wojciechowski_olagoke_ng_wacnik_kramer_2025/problem.toml
+++ b/src/design_research_problems/_assets/catalog/ideation/household_moving/wojciechowski_olagoke_ng_wacnik_kramer_2025/problem.toml
@@ -1,0 +1,40 @@
+problem_id = "ideation_household_moving"
+title = "Household Moving Support"
+summary = "A primary-source ideation brief about reducing the burdens of moving households through difficult spaces, weather, and logistics."
+kind = "text"
+statement = '''
+# Household Moving Support
+
+Moving is considered one of the top stressors in life. When people move, they
+experience multiple challenges. For example: lifting heavy furniture,
+navigating through small spaces (door frames, corners, narrow hallways,
+stairs), keeping belongings organized, finding other people to help them move,
+continuing living (and even working) while belongings are in transit, and
+moving in extreme weather (snow, heat, rain). Design a way to help people move
+households.
+'''
+capabilities = ["statement-markdown", "citation-backed", "prompt-packet"]
+study_suitability = ["human-subjects-ready", "ideation-friendly"]
+
+[taxonomy]
+formulation = "textual_prompt"
+is_dynamic = false
+orientation = "engineering_practical"
+objective_mode = "qualitative"
+constraint_nature = "embedded-constraints"
+tags = ["text", "human-subjects", "ideation", "household", "moving", "logistics"]
+deliverable_type = "concepts"
+timebox_hint_minutes = 10
+participants = "individual"
+evaluation_mode = "idea_generation"
+
+[[citations]]
+key = "wojciechowski_olagoke_ng_wacnik_kramer_2025"
+kind = "inline"
+authors = ["Lauren Wojciechowski", "Uthman Olagoke", "Rowena Ng", "Peter Wacnik", "Julia Kramer"]
+title = "Musical Playlists to Improve the Ideation Environment: An Exploratory Study"
+year = 2025
+venue = "ASME IDETC/CIE 2025, DETC2025-164691"
+formatted_text = "Wojciechowski, Olagoke, Ng, Wacnik, and Kramer (2025). Musical Playlists to Improve the Ideation Environment: An Exploratory Study. ASME IDETC/CIE 2025, DETC2025-164691."
+raw_text = "Wojciechowski, Olagoke, Ng, Wacnik, and Kramer (2025). Musical Playlists to Improve the Ideation Environment: An Exploratory Study. ASME IDETC/CIE 2025, DETC2025-164691."
+provisional = true

--- a/src/design_research_problems/_assets/catalog/ideation/soil_moisture_measurement/bhatt_ammersdorfer_inkermann_2025/problem.toml
+++ b/src/design_research_problems/_assets/catalog/ideation/soil_moisture_measurement/bhatt_ammersdorfer_inkermann_2025/problem.toml
@@ -1,0 +1,35 @@
+problem_id = "ideation_soil_moisture_measurement"
+title = "Soil Moisture Measurement for Lawns"
+summary = "A primary-source classroom ideation brief about measuring soil moisture to water lawns more efficiently under water constraints."
+kind = "text"
+statement = '''
+# Soil Moisture Measurement for Lawns
+
+Limitation of water resources is raising the demand for devices to measure
+moisture in soils in order to be able to water lawns efficiently.
+'''
+capabilities = ["statement-markdown", "citation-backed", "prompt-packet"]
+study_suitability = ["human-subjects-ready", "ideation-friendly"]
+
+[taxonomy]
+formulation = "textual_prompt"
+is_dynamic = false
+orientation = "engineering_practical"
+objective_mode = "qualitative"
+constraint_nature = "embedded-constraints"
+tags = ["text", "human-subjects", "ideation", "water", "sensing", "landscape"]
+deliverable_type = "concepts"
+timebox_hint_minutes = 30
+participants = "team"
+evaluation_mode = "idea_generation"
+
+[[citations]]
+key = "bhatt_ammersdorfer_inkermann_2025"
+kind = "inline"
+authors = ["Apoorv Naresh Bhatt", "Theresa Ammersdorfer", "David Inkermann"]
+title = "Impact of Problem Brief Characteristics and Influencing Factors on Design Outcomes in a Project-Based Engineering Course"
+year = 2025
+venue = "ASME IDETC/CIE 2025, DETC2025-168538"
+formatted_text = "Bhatt, Ammersdorfer, and Inkermann (2025). Impact of Problem Brief Characteristics and Influencing Factors on Design Outcomes in a Project-Based Engineering Course. ASME IDETC/CIE 2025, DETC2025-168538."
+raw_text = "Bhatt, Ammersdorfer, and Inkermann (2025). Impact of Problem Brief Characteristics and Influencing Factors on Design Outcomes in a Project-Based Engineering Course. ASME IDETC/CIE 2025, DETC2025-168538."
+provisional = true

--- a/src/design_research_problems/_assets/catalog/ideation/sustainable_daily_helpers/bhatt_ammersdorfer_inkermann_2025/problem.toml
+++ b/src/design_research_problems/_assets/catalog/ideation/sustainable_daily_helpers/bhatt_ammersdorfer_inkermann_2025/problem.toml
@@ -1,0 +1,36 @@
+problem_id = "ideation_sustainable_daily_helpers"
+title = "Sustainable Daily Helpers"
+summary = "A primary-source classroom ideation brief about improving the sustainability of indoor transport and cleaning service devices."
+kind = "text"
+statement = '''
+# Sustainable Daily Helpers
+
+In order to ease tasks like indoor transport or cleaning, there is an
+increasing demand for service devices. How can we enhance the sustainability
+of these daily helpers?
+'''
+capabilities = ["statement-markdown", "citation-backed", "prompt-packet"]
+study_suitability = ["human-subjects-ready", "ideation-friendly"]
+
+[taxonomy]
+formulation = "textual_prompt"
+is_dynamic = false
+orientation = "engineering_practical"
+objective_mode = "qualitative"
+constraint_nature = "open"
+tags = ["text", "human-subjects", "ideation", "service-devices", "sustainability", "indoor"]
+deliverable_type = "concepts"
+timebox_hint_minutes = 30
+participants = "team"
+evaluation_mode = "idea_generation"
+
+[[citations]]
+key = "bhatt_ammersdorfer_inkermann_2025"
+kind = "inline"
+authors = ["Apoorv Naresh Bhatt", "Theresa Ammersdorfer", "David Inkermann"]
+title = "Impact of Problem Brief Characteristics and Influencing Factors on Design Outcomes in a Project-Based Engineering Course"
+year = 2025
+venue = "ASME IDETC/CIE 2025, DETC2025-168538"
+formatted_text = "Bhatt, Ammersdorfer, and Inkermann (2025). Impact of Problem Brief Characteristics and Influencing Factors on Design Outcomes in a Project-Based Engineering Course. ASME IDETC/CIE 2025, DETC2025-168538."
+raw_text = "Bhatt, Ammersdorfer, and Inkermann (2025). Impact of Problem Brief Characteristics and Influencing Factors on Design Outcomes in a Project-Based Engineering Course. ASME IDETC/CIE 2025, DETC2025-168538."
+provisional = true

--- a/src/design_research_problems/_assets/catalog/ideation/sustainable_diapering/wojciechowski_olagoke_ng_wacnik_kramer_2025/problem.toml
+++ b/src/design_research_problems/_assets/catalog/ideation/sustainable_diapering/wojciechowski_olagoke_ng_wacnik_kramer_2025/problem.toml
@@ -1,0 +1,40 @@
+problem_id = "ideation_sustainable_diapering"
+title = "Sustainable Infant Diapering"
+summary = "A primary-source ideation brief about keeping infants clean while reducing diaper-related waste, water use, and energy use."
+kind = "text"
+statement = '''
+# Sustainable Infant Diapering
+
+Infants can go through 10 diapers or more a day. Disposable diapers increase
+the amount of waste we add to landfills, and reusable diapers use a lot of
+water (reducing the amount of a precious resource) and energy (increasing CO2
+emissions). A new wave of diapers tries to combine reusable elements with
+disposal ones to minimize harmful effects, however, the functionality of this
+new product is a question. Design a way to keep infants clean and limit
+environmental impacts.
+'''
+capabilities = ["statement-markdown", "citation-backed", "prompt-packet"]
+study_suitability = ["human-subjects-ready", "ideation-friendly"]
+
+[taxonomy]
+formulation = "textual_prompt"
+is_dynamic = false
+orientation = "engineering_practical"
+objective_mode = "qualitative"
+constraint_nature = "embedded-constraints"
+tags = ["text", "human-subjects", "ideation", "childcare", "sustainability", "consumer"]
+deliverable_type = "concepts"
+timebox_hint_minutes = 10
+participants = "individual"
+evaluation_mode = "idea_generation"
+
+[[citations]]
+key = "wojciechowski_olagoke_ng_wacnik_kramer_2025"
+kind = "inline"
+authors = ["Lauren Wojciechowski", "Uthman Olagoke", "Rowena Ng", "Peter Wacnik", "Julia Kramer"]
+title = "Musical Playlists to Improve the Ideation Environment: An Exploratory Study"
+year = 2025
+venue = "ASME IDETC/CIE 2025, DETC2025-164691"
+formatted_text = "Wojciechowski, Olagoke, Ng, Wacnik, and Kramer (2025). Musical Playlists to Improve the Ideation Environment: An Exploratory Study. ASME IDETC/CIE 2025, DETC2025-164691."
+raw_text = "Wojciechowski, Olagoke, Ng, Wacnik, and Kramer (2025). Musical Playlists to Improve the Ideation Environment: An Exploratory Study. ASME IDETC/CIE 2025, DETC2025-164691."
+provisional = true

--- a/src/design_research_problems/_assets/catalog/ideation/sustainable_fdm_printing/bhatt_ammersdorfer_inkermann_2025/problem.toml
+++ b/src/design_research_problems/_assets/catalog/ideation/sustainable_fdm_printing/bhatt_ammersdorfer_inkermann_2025/problem.toml
@@ -1,0 +1,35 @@
+problem_id = "ideation_sustainable_fdm_printing"
+title = "Sustainable FDM Printing"
+summary = "A primary-source classroom ideation brief about evaluating and improving sustainability in FDM 3D printing."
+kind = "text"
+statement = '''
+# Sustainable FDM Printing
+
+Increasing amount of 3D printing (FDM) and resource limitation raises the
+question of how to evaluate and improve sustainability.
+'''
+capabilities = ["statement-markdown", "citation-backed", "prompt-packet"]
+study_suitability = ["human-subjects-ready", "ideation-friendly"]
+
+[taxonomy]
+formulation = "textual_prompt"
+is_dynamic = false
+orientation = "engineering_practical"
+objective_mode = "qualitative"
+constraint_nature = "open"
+tags = ["text", "human-subjects", "ideation", "manufacturing", "sustainability", "3d-printing"]
+deliverable_type = "concepts"
+timebox_hint_minutes = 30
+participants = "team"
+evaluation_mode = "idea_generation"
+
+[[citations]]
+key = "bhatt_ammersdorfer_inkermann_2025"
+kind = "inline"
+authors = ["Apoorv Naresh Bhatt", "Theresa Ammersdorfer", "David Inkermann"]
+title = "Impact of Problem Brief Characteristics and Influencing Factors on Design Outcomes in a Project-Based Engineering Course"
+year = 2025
+venue = "ASME IDETC/CIE 2025, DETC2025-168538"
+formatted_text = "Bhatt, Ammersdorfer, and Inkermann (2025). Impact of Problem Brief Characteristics and Influencing Factors on Design Outcomes in a Project-Based Engineering Course. ASME IDETC/CIE 2025, DETC2025-168538."
+raw_text = "Bhatt, Ammersdorfer, and Inkermann (2025). Impact of Problem Brief Characteristics and Influencing Factors on Design Outcomes in a Project-Based Engineering Course. ASME IDETC/CIE 2025, DETC2025-168538."
+provisional = true

--- a/src/design_research_problems/_assets/ideation/catalog.toml
+++ b/src/design_research_problems/_assets/ideation/catalog.toml
@@ -496,6 +496,28 @@ formatted_text = "Lemons, Carberry, Swan, Jarvin, and Rogers (2010). The benefit
 raw_text = "Lemons, Carberry, Swan, Jarvin, and Rogers (2010). The benefits of model building in teaching engineering design. Design Studies, 31(3), 288-309. DOI: 10.1016/j.destud.2010.02.001."
 provisional = false
 
+[[citations]]
+key = "wojciechowski_olagoke_ng_wacnik_kramer_2025"
+kind = "inline"
+authors = ["Lauren Wojciechowski", "Uthman Olagoke", "Rowena Ng", "Peter Wacnik", "Julia Kramer"]
+title = "Musical Playlists to Improve the Ideation Environment: An Exploratory Study"
+year = 2025
+venue = "ASME IDETC/CIE 2025, DETC2025-164691"
+formatted_text = "Wojciechowski, Olagoke, Ng, Wacnik, and Kramer (2025). Musical Playlists to Improve the Ideation Environment: An Exploratory Study. ASME IDETC/CIE 2025, DETC2025-164691."
+raw_text = "Wojciechowski, Olagoke, Ng, Wacnik, and Kramer (2025). Musical Playlists to Improve the Ideation Environment: An Exploratory Study. ASME IDETC/CIE 2025, DETC2025-164691."
+provisional = true
+
+[[citations]]
+key = "bhatt_ammersdorfer_inkermann_2025"
+kind = "inline"
+authors = ["Apoorv Naresh Bhatt", "Theresa Ammersdorfer", "David Inkermann"]
+title = "Impact of Problem Brief Characteristics and Influencing Factors on Design Outcomes in a Project-Based Engineering Course"
+year = 2025
+venue = "ASME IDETC/CIE 2025, DETC2025-168538"
+formatted_text = "Bhatt, Ammersdorfer, and Inkermann (2025). Impact of Problem Brief Characteristics and Influencing Factors on Design Outcomes in a Project-Based Engineering Course. ASME IDETC/CIE 2025, DETC2025-168538."
+raw_text = "Bhatt, Ammersdorfer, and Inkermann (2025). Impact of Problem Brief Characteristics and Influencing Factors on Design Outcomes in a Project-Based Engineering Course. ASME IDETC/CIE 2025, DETC2025-168538."
+provisional = true
+
 [[families]]
 family_id = "family_chocolate_packaging"
 name = "Chocolate Packaging"
@@ -720,6 +742,78 @@ external_aliases = []
 canonical_prompt_ids = ["prompt_home_energy_conservation"]
 tags = ["sustainability", "energy", "home"]
 notes = "Original training problem introduced by Goucher-Lambert and Cagan (2019)."
+
+[[families]]
+family_id = "family_dark_hour_safety"
+name = "Dark-Hour Safety"
+group = "transport-infrastructure"
+external_aliases = []
+canonical_prompt_ids = ["prompt_dark_hour_safety"]
+tags = ["safety", "mobility", "public-space"]
+notes = "Wojciechowski et al. (2025) reproduces this participant-facing prompt from a University of Michigan ideation study based on Shanna Daly's Front-End Design course material."
+
+[[families]]
+family_id = "family_household_moving"
+name = "Household Moving"
+group = "consumer-household"
+external_aliases = []
+canonical_prompt_ids = ["prompt_household_moving"]
+tags = ["moving", "household", "logistics"]
+notes = "Wojciechowski et al. (2025) reproduces this participant-facing moving-households brief from a University of Michigan ideation study."
+
+[[families]]
+family_id = "family_sustainable_diapering"
+name = "Sustainable Diapering"
+group = "consumer-household"
+external_aliases = []
+canonical_prompt_ids = ["prompt_sustainable_diapering"]
+tags = ["childcare", "sustainability", "consumer"]
+notes = "Wojciechowski et al. (2025) reproduces this participant-facing diapering brief focused on infant cleanliness and environmental impact."
+
+[[families]]
+family_id = "family_entryway_track_removal"
+name = "Entryway Track Removal"
+group = "transport-infrastructure"
+external_aliases = []
+canonical_prompt_ids = ["prompt_entryway_track_removal"]
+tags = ["cleaning", "safety", "public-space"]
+notes = "Wojciechowski et al. (2025) reproduces this participant-facing brief about removing tracked dirt, snow, and water before building entry."
+
+[[families]]
+family_id = "family_forest_fire_detection"
+name = "Forest Fire Detection"
+group = "sustainability-waste"
+external_aliases = []
+canonical_prompt_ids = ["prompt_forest_fire_detection"]
+tags = ["wildfire", "sensing", "environment"]
+notes = "Bhatt, Ammersdorfer, and Inkermann (2025) lists this classroom problem brief in Table 1 as Topic A."
+
+[[families]]
+family_id = "family_sustainable_fdm_printing"
+name = "Sustainable FDM Printing"
+group = "sustainability-waste"
+external_aliases = []
+canonical_prompt_ids = ["prompt_sustainable_fdm_printing"]
+tags = ["manufacturing", "sustainability", "3d-printing"]
+notes = "Bhatt, Ammersdorfer, and Inkermann (2025) lists this classroom problem brief in Table 1 as Topic B."
+
+[[families]]
+family_id = "family_soil_moisture_measurement"
+name = "Soil Moisture Measurement"
+group = "sustainability-waste"
+external_aliases = []
+canonical_prompt_ids = ["prompt_soil_moisture_measurement"]
+tags = ["water", "sensing", "landscape"]
+notes = "Bhatt, Ammersdorfer, and Inkermann (2025) lists this classroom problem brief in Table 1 as Topic C."
+
+[[families]]
+family_id = "family_sustainable_daily_helpers"
+name = "Sustainable Daily Helpers"
+group = "consumer-household"
+external_aliases = []
+canonical_prompt_ids = ["prompt_sustainable_daily_helpers"]
+tags = ["service-devices", "sustainability", "indoor"]
+notes = "Bhatt, Ammersdorfer, and Inkermann (2025) lists this classroom problem brief in Table 1 as Topic D."
 
 [[prompts]]
 prompt_id = "prompt_travel_exercise_device"
@@ -1174,6 +1268,94 @@ tags = ["sustainability", "energy", "ideation"]
 status = "complete"
 variant_ids = ["variant_home_energy_conservation"]
 
+[[prompts]]
+prompt_id = "prompt_dark_hour_safety"
+problem_id = "ideation_dark_hour_safety"
+family_id = "family_dark_hour_safety"
+canonical_brief = "The shorter daylight hours that come with the seasons can increase safety concerns for many, including those who walk to commute, runners who exercise early in the morning or late at night, and students going home late from the library or social events. Design a way to support safety in the dark morning and evening hours."
+evidence_tier = "primary_verbatim"
+source_citation_keys = ["wojciechowski_olagoke_ng_wacnik_kramer_2025"]
+tags = ["safety", "mobility", "ideation"]
+status = "complete"
+variant_ids = ["variant_dark_hour_safety"]
+
+[[prompts]]
+prompt_id = "prompt_household_moving"
+problem_id = "ideation_household_moving"
+family_id = "family_household_moving"
+canonical_brief = "Moving is considered one of the top stressors in life. When people move, they experience multiple challenges. For example: lifting heavy furniture, navigating through small spaces (door frames, corners, narrow hallways, stairs), keeping belongings organized, finding other people to help them move, continuing living (and even working) while belongings are in transit, and moving in extreme weather (snow, heat, rain). Design a way to help people move households."
+evidence_tier = "primary_verbatim"
+source_citation_keys = ["wojciechowski_olagoke_ng_wacnik_kramer_2025"]
+tags = ["household", "moving", "ideation"]
+status = "complete"
+variant_ids = ["variant_household_moving"]
+
+[[prompts]]
+prompt_id = "prompt_sustainable_diapering"
+problem_id = "ideation_sustainable_diapering"
+family_id = "family_sustainable_diapering"
+canonical_brief = "Infants can go through 10 diapers or more a day. Disposable diapers increase the amount of waste we add to landfills, and reusable diapers use a lot of water (reducing the amount of a precious resource) and energy (increasing CO2 emissions). A new wave of diapers tries to combine reusable elements with disposal ones to minimize harmful effects, however, the functionality of this new product is a question. Design a way to keep infants clean and limit environmental impacts."
+evidence_tier = "primary_verbatim"
+source_citation_keys = ["wojciechowski_olagoke_ng_wacnik_kramer_2025"]
+tags = ["childcare", "sustainability", "ideation"]
+status = "complete"
+variant_ids = ["variant_sustainable_diapering"]
+
+[[prompts]]
+prompt_id = "prompt_entryway_track_removal"
+problem_id = "ideation_entryway_track_removal"
+family_id = "family_entryway_track_removal"
+canonical_brief = "Building entrances often become messy and unsafe due to snow, dirt, and water being tracked inside. Floor mats and fans are often used to mitigate the issue, but people often do not wipe their feet or use the fans. Design an intuitive way to remove tracks in dirt, snow, and water from individuals' shoes before they enter into a building."
+evidence_tier = "primary_verbatim"
+source_citation_keys = ["wojciechowski_olagoke_ng_wacnik_kramer_2025"]
+tags = ["cleaning", "safety", "ideation"]
+status = "complete"
+variant_ids = ["variant_entryway_track_removal"]
+
+[[prompts]]
+prompt_id = "prompt_forest_fire_detection"
+problem_id = "ideation_forest_fire_detection"
+family_id = "family_forest_fire_detection"
+canonical_brief = "There is an increasing need to prevent fire in local forests. We need a device to detect upcoming fires in a reliable way."
+evidence_tier = "primary_verbatim"
+source_citation_keys = ["bhatt_ammersdorfer_inkermann_2025"]
+tags = ["wildfire", "sensing", "ideation"]
+status = "complete"
+variant_ids = ["variant_forest_fire_detection"]
+
+[[prompts]]
+prompt_id = "prompt_sustainable_fdm_printing"
+problem_id = "ideation_sustainable_fdm_printing"
+family_id = "family_sustainable_fdm_printing"
+canonical_brief = "Increasing amount of 3D printing (FDM) and resource limitation raises the question of how to evaluate and improve sustainability."
+evidence_tier = "primary_verbatim"
+source_citation_keys = ["bhatt_ammersdorfer_inkermann_2025"]
+tags = ["manufacturing", "sustainability", "ideation"]
+status = "complete"
+variant_ids = ["variant_sustainable_fdm_printing"]
+
+[[prompts]]
+prompt_id = "prompt_soil_moisture_measurement"
+problem_id = "ideation_soil_moisture_measurement"
+family_id = "family_soil_moisture_measurement"
+canonical_brief = "Limitation of water resources is raising the demand for devices to measure moisture in soils in order to be able to water lawns efficiently."
+evidence_tier = "primary_verbatim"
+source_citation_keys = ["bhatt_ammersdorfer_inkermann_2025"]
+tags = ["water", "sensing", "ideation"]
+status = "complete"
+variant_ids = ["variant_soil_moisture_measurement"]
+
+[[prompts]]
+prompt_id = "prompt_sustainable_daily_helpers"
+problem_id = "ideation_sustainable_daily_helpers"
+family_id = "family_sustainable_daily_helpers"
+canonical_brief = "In order to ease tasks like indoor transport or cleaning, there is an increasing demand for service devices. How can we enhance the sustainability of these daily helpers?"
+evidence_tier = "primary_verbatim"
+source_citation_keys = ["bhatt_ammersdorfer_inkermann_2025"]
+tags = ["service-devices", "sustainability", "ideation"]
+status = "complete"
+variant_ids = ["variant_sustainable_daily_helpers"]
+
 [[variants]]
 variant_id = "variant_travel_exercise_device"
 prompt_id = "prompt_travel_exercise_device"
@@ -1625,6 +1807,94 @@ statement_type = "study-specific"
 evidence_tier = "primary_verbatim"
 source_citation_keys = ["goucher_lambert_cagan_2019"]
 notes = "Verbatim original training prompt listed as Problem NA in Table 1 of Goucher-Lambert and Cagan (2019)."
+status = "complete"
+
+[[variants]]
+variant_id = "variant_dark_hour_safety"
+prompt_id = "prompt_dark_hour_safety"
+problem_id = "ideation_dark_hour_safety"
+label = "Wojciechowski et al. (2025) study prompt"
+statement_type = "study-specific"
+evidence_tier = "primary_verbatim"
+source_citation_keys = ["wojciechowski_olagoke_ng_wacnik_kramer_2025"]
+notes = "Verbatim prompt block reproduced in the accessible 2025 paper and credited there to Shanna Daly's Front-End Design course material."
+status = "complete"
+
+[[variants]]
+variant_id = "variant_household_moving"
+prompt_id = "prompt_household_moving"
+problem_id = "ideation_household_moving"
+label = "Wojciechowski et al. (2025) study prompt"
+statement_type = "study-specific"
+evidence_tier = "primary_verbatim"
+source_citation_keys = ["wojciechowski_olagoke_ng_wacnik_kramer_2025"]
+notes = "Verbatim moving-households prompt block reproduced in the accessible 2025 paper."
+status = "complete"
+
+[[variants]]
+variant_id = "variant_sustainable_diapering"
+prompt_id = "prompt_sustainable_diapering"
+problem_id = "ideation_sustainable_diapering"
+label = "Wojciechowski et al. (2025) study prompt"
+statement_type = "study-specific"
+evidence_tier = "primary_verbatim"
+source_citation_keys = ["wojciechowski_olagoke_ng_wacnik_kramer_2025"]
+notes = "Verbatim infant-diapering prompt block reproduced in the accessible 2025 paper."
+status = "complete"
+
+[[variants]]
+variant_id = "variant_entryway_track_removal"
+prompt_id = "prompt_entryway_track_removal"
+problem_id = "ideation_entryway_track_removal"
+label = "Wojciechowski et al. (2025) study prompt"
+statement_type = "study-specific"
+evidence_tier = "primary_verbatim"
+source_citation_keys = ["wojciechowski_olagoke_ng_wacnik_kramer_2025"]
+notes = "Verbatim building-entry prompt block reproduced in the accessible 2025 paper."
+status = "complete"
+
+[[variants]]
+variant_id = "variant_forest_fire_detection"
+prompt_id = "prompt_forest_fire_detection"
+problem_id = "ideation_forest_fire_detection"
+label = "Bhatt, Ammersdorfer, and Inkermann (2025) project brief"
+statement_type = "study-specific"
+evidence_tier = "primary_verbatim"
+source_citation_keys = ["bhatt_ammersdorfer_inkermann_2025"]
+notes = "Verbatim classroom project brief listed in Table 1 as Topic A."
+status = "complete"
+
+[[variants]]
+variant_id = "variant_sustainable_fdm_printing"
+prompt_id = "prompt_sustainable_fdm_printing"
+problem_id = "ideation_sustainable_fdm_printing"
+label = "Bhatt, Ammersdorfer, and Inkermann (2025) project brief"
+statement_type = "study-specific"
+evidence_tier = "primary_verbatim"
+source_citation_keys = ["bhatt_ammersdorfer_inkermann_2025"]
+notes = "Verbatim classroom project brief listed in Table 1 as Topic B."
+status = "complete"
+
+[[variants]]
+variant_id = "variant_soil_moisture_measurement"
+prompt_id = "prompt_soil_moisture_measurement"
+problem_id = "ideation_soil_moisture_measurement"
+label = "Bhatt, Ammersdorfer, and Inkermann (2025) project brief"
+statement_type = "study-specific"
+evidence_tier = "primary_verbatim"
+source_citation_keys = ["bhatt_ammersdorfer_inkermann_2025"]
+notes = "Verbatim classroom project brief listed in Table 1 as Topic C."
+status = "complete"
+
+[[variants]]
+variant_id = "variant_sustainable_daily_helpers"
+prompt_id = "prompt_sustainable_daily_helpers"
+problem_id = "ideation_sustainable_daily_helpers"
+label = "Bhatt, Ammersdorfer, and Inkermann (2025) project brief"
+statement_type = "study-specific"
+evidence_tier = "primary_verbatim"
+source_citation_keys = ["bhatt_ammersdorfer_inkermann_2025"]
+notes = "Verbatim classroom project brief listed in Table 1 as Topic D."
 status = "complete"
 
 [[studies]]

--- a/tests/test_ideation_catalog.py
+++ b/tests/test_ideation_catalog.py
@@ -11,9 +11,9 @@ from design_research_problems._catalog._validation import validate_catalog
 
 def test_ideation_catalog_exposes_expected_table_sizes() -> None:
     catalog = get_ideation_catalog()
-    assert len(catalog.list_prompts()) == 40
-    assert len(catalog.list_variants()) == 40
-    assert len(catalog.list_families()) == 22
+    assert len(catalog.list_prompts()) == 48
+    assert len(catalog.list_variants()) == 48
+    assert len(catalog.list_families()) == 30
     assert len(catalog.list_studies()) == 6
 
 

--- a/tests/test_registry_and_problems.py
+++ b/tests/test_registry_and_problems.py
@@ -73,8 +73,10 @@ def test_registry_entries_filter_by_kind() -> None:
     assert set(MSEVAL_IDS).issubset(decision_ids)
     kinds = registry.by_kind(ProblemKind.TEXT)
     text_ids = [entry.problem_id for entry in kinds]
-    assert len(text_ids) == 40
+    assert len(text_ids) == 48
     assert "ideation_accessible_drinking_fountain" in text_ids
+    assert "ideation_dark_hour_safety" in text_ids
+    assert "ideation_forest_fire_detection" in text_ids
     assert "ideation_public_belongings_security" in text_ids
     assert "ideation_wheelchair_peach_picking" in text_ids
     assert registry.feature_flags("ideation_peanut_shelling_fu_cagan_kotovsky_2010") == (
@@ -170,6 +172,15 @@ def test_text_problem_can_render_summary_and_raw_citations() -> None:
     assert "## Sources" in packet
     assert "## BibTeX" in packet
     assert "@article{fu2010design," in packet
+
+
+def test_new_2025_ideation_problem_renders_statement_and_citation() -> None:
+    problem = get_problem("ideation_dark_hour_safety")
+    assert isinstance(problem, Problem)
+    packet = problem.render_brief()
+    assert packet.count("# Dark-Hour Safety") == 1
+    assert "Design a way to support safety in the dark morning" in packet
+    assert "Wojciechowski, Olagoke, Ng, Wacnik, and Kramer (2025)." in packet
 
 
 def test_decision_problem_exposes_structured_brief() -> None:


### PR DESCRIPTION
## Summary
- add 8 new ideation prompts sourced from 2025 IDETC papers into the packaged catalog
- register the new prompt families, prompts, variants, and citations in the ideation metadata catalog
- update README and ideation tests/docs to reflect the expanded text corpus counts

## Validation
- `.venv/bin/python -m pytest tests/test_ideation_catalog.py tests/test_registry_and_problems.py`
- `.venv/bin/python scripts/check_docs_consistency.py`
- `.venv/bin/python - <<'PY'
from design_research_problems._catalog._validation import validate_catalog
report = validate_catalog()
print(len(report.errors))
PY`
