### PR TITLE
[codex] Add packaged problem MCP CLI

### DIFF
--- a/docs/problems/mcp.rst
+++ b/docs/problems/mcp.rst
@@ -18,3 +18,46 @@ to the current Python interpreter path before launching the upstream server.
 The catalog currently includes ``mcp_build123d_parametric_mounting_bracket`` for
 CAD-oriented agent workflows where the agent writes and evaluates Build123d
 scripts through a package-owned backend.
+
+Packaged Problem Server
+-----------------------
+
+Any packaged problem that implements ``to_mcp_server()`` can be served directly
+from the package CLI. This avoids writing a temporary server script in a
+notebook before connecting another agent runtime.
+
+.. code-block:: bash
+
+   python -m design_research_problems.mcp pill_capsule_min_area --no-citation
+
+Use the same module path from a stdio-capable MCP client. For example, a
+notebook that uses ``design-research-agents`` can point its toolbox at the
+packaged problem server:
+
+.. code-block:: python
+
+   import sys
+
+   import design_research_agents as drag
+
+   toolbox = drag.Toolbox(
+       enable_core_tools=False,
+       mcp_servers=(
+           drag.MCPServerConfig(
+               id="drp_problem",
+               command=(
+                   sys.executable,
+                   "-m",
+                   "design_research_problems.mcp",
+                   "pill_capsule_min_area",
+                   "--no-citation",
+               ),
+           ),
+       ),
+   )
+
+Install the MCP extra first when the optional dependency is not already present:
+
+.. code-block:: bash
+
+   pip install "design-research-problems[mcp]"

--- a/src/design_research_problems/mcp.py
+++ b/src/design_research_problems/mcp.py
@@ -1,0 +1,86 @@
+"""Command-line entrypoint for serving packaged problems over MCP stdio."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+from typing import Any
+
+from design_research_problems import MissingOptionalDependencyError, get_problem
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the problem MCP server CLI parser.
+
+    Returns:
+        Configured argument parser.
+    """
+    parser = argparse.ArgumentParser(
+        prog="python -m design_research_problems.mcp",
+        description="Serve one packaged design-research problem as an MCP stdio server.",
+    )
+    parser.add_argument("problem_id", help="Packaged problem id to expose.")
+    parser.add_argument(
+        "--server-name",
+        default=None,
+        help="Optional MCP server name. Defaults to the problem's package-provided name.",
+    )
+    parser.add_argument(
+        "--no-citation",
+        action="store_true",
+        help="Omit citation text from the served problem brief when supported.",
+    )
+    parser.add_argument(
+        "--transport",
+        choices=("stdio",),
+        default="stdio",
+        help="MCP transport to run. Only stdio is supported.",
+    )
+    return parser
+
+
+def create_problem_server(problem_id: str, *, server_name: str | None = None, include_citation: bool = True) -> Any:
+    """Create a FastMCP server for one packaged problem.
+
+    Args:
+        problem_id: Packaged problem id to load.
+        server_name: Optional MCP server name override.
+        include_citation: Whether to include citation text in the problem brief.
+
+    Returns:
+        Configured FastMCP server.
+    """
+    problem = get_problem(problem_id)
+    return problem.to_mcp_server(server_name=server_name, include_citation=include_citation)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the packaged problem MCP server CLI.
+
+    Args:
+        argv: Optional argument sequence excluding the executable name.
+
+    Returns:
+        Process-style exit code. Real server runs usually block until the stdio
+        transport closes.
+    """
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        server = create_problem_server(
+            args.problem_id,
+            server_name=args.server_name,
+            include_citation=not args.no_citation,
+        )
+    except MissingOptionalDependencyError as exc:
+        parser.exit(
+            2,
+            f"{exc}\nInstall optional MCP support with: pip install 'design-research-problems[mcp]'\n",
+        )
+
+    server.run(transport=args.transport)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_mcp_cli.py
+++ b/tests/test_mcp_cli.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from design_research_problems import MissingOptionalDependencyError
+from design_research_problems import mcp as mcp_cli
+
+
+class _FakeServer:
+    def __init__(self) -> None:
+        self.transport: str | None = None
+
+    def run(self, *, transport: str) -> None:
+        self.transport = transport
+
+
+class _FakeProblem:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def to_mcp_server(self, *, server_name: str | None = None, include_citation: bool = True) -> _FakeServer:
+        self.calls.append({"server_name": server_name, "include_citation": include_citation})
+        return _FakeServer()
+
+
+def test_build_parser_accepts_notebook_friendly_options() -> None:
+    args = mcp_cli.build_parser().parse_args(("pill_capsule_min_area", "--server-name", "drp_problem", "--no-citation"))
+
+    assert args.problem_id == "pill_capsule_min_area"
+    assert args.server_name == "drp_problem"
+    assert args.no_citation is True
+    assert args.transport == "stdio"
+
+
+def test_create_problem_server_loads_problem_and_forwards_server_options(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_problem = _FakeProblem()
+    monkeypatch.setattr(mcp_cli, "get_problem", lambda problem_id: fake_problem)
+
+    server = mcp_cli.create_problem_server(
+        "pill_capsule_min_area",
+        server_name="drp_problem",
+        include_citation=False,
+    )
+
+    assert isinstance(server, _FakeServer)
+    assert fake_problem.calls == [{"server_name": "drp_problem", "include_citation": False}]
+
+
+def test_main_runs_created_server(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_server = _FakeServer()
+
+    def create_problem_server(problem_id: str, **kwargs: Any) -> _FakeServer:
+        assert problem_id == "pill_capsule_min_area"
+        assert kwargs == {"server_name": None, "include_citation": False}
+        return fake_server
+
+    monkeypatch.setattr(mcp_cli, "create_problem_server", create_problem_server)
+
+    assert mcp_cli.main(("pill_capsule_min_area", "--no-citation")) == 0
+    assert fake_server.transport == "stdio"
+
+
+def test_main_reports_missing_mcp_extra(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    def create_problem_server(problem_id: str, **kwargs: Any) -> _FakeServer:
+        raise MissingOptionalDependencyError("missing mcp")
+
+    monkeypatch.setattr(mcp_cli, "create_problem_server", create_problem_server)
+
+    with pytest.raises(SystemExit) as exc_info:
+        mcp_cli.main(("pill_capsule_min_area",))
+
+    assert exc_info.value.code == 2
+    assert "design-research-problems[mcp]" in capsys.readouterr().err


### PR DESCRIPTION
## What changed
- add `python -m design_research_problems.mcp <problem_id>` as a package-owned stdio MCP entrypoint
- support server-name, no-citation, and stdio transport options
- add focused CLI tests and developer-oriented MCP docs

## Why
The forwarded PillOptimizer flow had to write a temporary server script before an agent could call packaged problem tools. This lets developers launch packaged problem servers directly from notebooks, scripts, or other local workflows.

## Validation
- `PYTHONPATH=src uv run --extra dev --python 3.12 python -m pytest -q tests/test_mcp_cli.py`
- `uv run --extra dev --python 3.12 python -m ruff check src/design_research_problems/mcp.py tests/test_mcp_cli.py`
- `uv run --extra dev --python 3.12 python -m ruff format --check src/design_research_problems/mcp.py tests/test_mcp_cli.py`
- `PYTHONPATH=src uv run --extra dev --python 3.12 python -m mypy src/design_research_problems/mcp.py`

Refs #79.
Pairs with cmudrc/design-research-agents#103.
