### PR TITLE
[codex] Add DERP catalog summaries and solver hints

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -20,6 +20,7 @@ The top-level package exports a small curated public API:
 - ``OptimizationProblem``
 - ``Problem``
 - ``ProblemAsset``
+- ``ProblemCatalogSummary``
 - ``ProblemEvaluationError``
 - ``ProblemKind``
 - ``ProblemMetadata``
@@ -29,5 +30,6 @@ The top-level package exports a small curated public API:
 - ``get_ideation_catalog``
 - ``get_problem``
 - ``list_problems``
+- ``search_problem_summaries``
 
 See :doc:`reference/index` for the module-level reference pages.

--- a/docs/dependencies_and_extras.rst
+++ b/docs/dependencies_and_extras.rst
@@ -65,6 +65,8 @@ Recommended install profiles:
 - structural grammar studies: ``pip install -e ".[grammar]"``
 - battery studies: ``pip install -e ".[battery]"``
 - external-tool workflows: ``pip install -e ".[mcp,cad]"``
+- DRAG/DERP agent workflows:
+  ``pip install "design-research-agents[mcp,gemini]" "design-research-problems[mcp]"``
 - broad optional-toolkit install: ``pip install -e ".[all]"``
 - full local validation environment: ``make dev-full``
 

--- a/docs/problems/optimization.rst
+++ b/docs/problems/optimization.rst
@@ -3,6 +3,11 @@ Optimization Problems
 
 Optimization problems expose typed bounds, solver-independent constraints, and
 problem-specific representative baseline `solve()` implementations.
+They also expose `solver_hints()` for agent-facing solver selection. The hint
+payload includes variable domain, numeric bounds, constraint counts, objective
+mode, and a compact solver-family recommendation, and the same payload is
+available through the `solver_hints` tool when an optimization problem is served
+over MCP.
 
 The smooth continuous packaged benchmarks in this family continue to use SciPy
 baselines.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -30,8 +30,15 @@ Or install from source:
    import design_research_problems as derp
 
    print(f"Catalog size: {len(derp.list_problems())}")
+   summaries = derp.search_problem_summaries(text="pill", kind="optimization")
+   print(summaries[0].to_dict())
+
    problem = derp.get_problem("ideation_peanut_shelling_fu_cagan_kotovsky_2010")
    print(problem.render_brief(include_citation=False))
+
+   optimization = derp.get_problem("pill_capsule_min_area")
+   if isinstance(optimization, derp.OptimizationProblem):
+       print(optimization.solver_hints())
 
 3. What Happened
 ----------------
@@ -39,6 +46,11 @@ Or install from source:
 You loaded one packaged study task from the catalog and rendered its design
 brief. This is the core pattern for building comparable task inputs before
 adding evaluators, solvers, or orchestration.
+
+``search_problem_summaries`` returns compact metadata for selection and routing
+without putting every full problem brief into an agent context window.
+Optimization problems also expose ``solver_hints()`` so callers can see bounds,
+variable domain, constraint counts, and a solver-family hint directly.
 
 4. Where To Go Next
 -------------------

--- a/src/design_research_problems/__init__.py
+++ b/src/design_research_problems/__init__.py
@@ -13,6 +13,7 @@ _EXPORTS: Final[dict[str, str]] = {
     "ComputableProblem": "design_research_problems.problems:ComputableProblem",
     "ProblemKind": "design_research_problems.problems:ProblemKind",
     "ProblemMetadata": "design_research_problems.problems:ProblemMetadata",
+    "ProblemCatalogSummary": "design_research_problems.problems:ProblemCatalogSummary",
     "ProblemTaxonomy": "design_research_problems.problems:ProblemTaxonomy",
     "Citation": "design_research_problems.problems:Citation",
     "ProblemAsset": "design_research_problems.problems:ProblemAsset",
@@ -36,6 +37,7 @@ _EXPORTS: Final[dict[str, str]] = {
     "get_problem": "design_research_problems._catalog:get_problem",
     "get_problem_as": "design_research_problems._catalog:get_problem_as",
     "list_problems": "design_research_problems._catalog:list_problems",
+    "search_problem_summaries": "design_research_problems._catalog:search_problem_summaries",
     "get_ideation_catalog": "design_research_problems.ideation:get_ideation_catalog",
 }
 
@@ -84,6 +86,7 @@ if TYPE_CHECKING:
     from ._catalog import get_problem as get_problem
     from ._catalog import get_problem_as as get_problem_as
     from ._catalog import list_problems as list_problems
+    from ._catalog import search_problem_summaries as search_problem_summaries
     from ._exceptions import MissingOptionalDependencyError as MissingOptionalDependencyError
     from ._exceptions import ProblemEvaluationError as ProblemEvaluationError
     from .ideation import EvidenceTier as EvidenceTier
@@ -106,6 +109,7 @@ if TYPE_CHECKING:
     from .problems import OptimizationProblem as OptimizationProblem
     from .problems import Problem as Problem
     from .problems import ProblemAsset as ProblemAsset
+    from .problems import ProblemCatalogSummary as ProblemCatalogSummary
     from .problems import ProblemKind as ProblemKind
     from .problems import ProblemMetadata as ProblemMetadata
     from .problems import ProblemTaxonomy as ProblemTaxonomy

--- a/src/design_research_problems/_catalog/__init__.py
+++ b/src/design_research_problems/_catalog/__init__.py
@@ -1,5 +1,5 @@
 """Catalog loading and registry exports."""
 
-from ._registry import ProblemRegistry, get_problem, get_problem_as, list_problems
+from ._registry import ProblemRegistry, get_problem, get_problem_as, list_problems, search_problem_summaries
 
-__all__ = ["ProblemRegistry", "get_problem", "get_problem_as", "list_problems"]
+__all__ = ["ProblemRegistry", "get_problem", "get_problem_as", "list_problems", "search_problem_summaries"]

--- a/src/design_research_problems/_catalog/_registry.py
+++ b/src/design_research_problems/_catalog/_registry.py
@@ -11,7 +11,7 @@ from design_research_problems._catalog._manifest import ProblemManifest
 from design_research_problems._exceptions import ProblemEvaluationError
 from design_research_problems.problems import MCPProblem, Problem, ProblemKind, TextProblem
 from design_research_problems.problems._decision import load_decision_problem
-from design_research_problems.problems._metadata import ProblemMetadata
+from design_research_problems.problems._metadata import ProblemCatalogSummary, ProblemMetadata
 
 if TYPE_CHECKING:
     from design_research_problems.problems import (
@@ -287,6 +287,40 @@ class ProblemRegistry:
             matches.append(metadata)
         return tuple(matches)
 
+    def summaries(
+        self,
+        tags: tuple[str, ...] = (),
+        text: str = "",
+        feature_flags: tuple[str, ...] = (),
+        kind: ProblemKind | None = None,
+        capabilities: tuple[str, ...] = (),
+        study_suitability: tuple[str, ...] = (),
+    ) -> tuple[ProblemCatalogSummary, ...]:
+        """Return compact search results for agent-facing problem selection.
+
+        Args:
+            tags: Tags that must all be present on a matching entry.
+            text: Case-insensitive free-text search term.
+            feature_flags: Feature flags that must all be present on a matching entry.
+            kind: Optional problem-family filter.
+            capabilities: Capability flags that must all be present.
+            study_suitability: Study-suitability flags that must all be present.
+
+        Returns:
+            Compact summaries for matching entries in deterministic order.
+        """
+        return tuple(
+            ProblemCatalogSummary.from_metadata(metadata)
+            for metadata in self.search(
+                tags=tags,
+                text=text,
+                feature_flags=feature_flags,
+                kind=kind,
+                capabilities=capabilities,
+                study_suitability=study_suitability,
+            )
+        )
+
     @overload
     def get(
         self, problem_id: Literal["battery_18650_t1_rectangular_surrogate_grammar"]
@@ -489,6 +523,20 @@ class ProblemRegistry:
 _DEFAULT_REGISTRY = ProblemRegistry()
 
 
+def _coerce_problem_kind(kind: ProblemKind | str | None) -> ProblemKind | None:
+    """Normalize an optional problem-kind filter.
+
+    Args:
+        kind: ProblemKind value, string value, or ``None``.
+
+    Returns:
+        Normalized kind or ``None``.
+    """
+    if kind is None or isinstance(kind, ProblemKind):
+        return kind
+    return ProblemKind(kind.strip().lower())
+
+
 def list_problems() -> tuple[str, ...]:
     """Return all packaged problem IDs.
 
@@ -496,6 +544,46 @@ def list_problems() -> tuple[str, ...]:
         Stable problem IDs in sorted order.
     """
     return tuple(metadata.problem_id for metadata in _DEFAULT_REGISTRY.list())
+
+
+def search_problem_summaries(
+    *,
+    tags: tuple[str, ...] = (),
+    text: str = "",
+    feature_flags: tuple[str, ...] = (),
+    kind: ProblemKind | str | None = None,
+    capabilities: tuple[str, ...] = (),
+    study_suitability: tuple[str, ...] = (),
+) -> tuple[ProblemCatalogSummary, ...]:
+    """Search the packaged catalog and return compact problem summaries.
+
+    This is the agent-facing counterpart to loading full briefs with
+    ``get_problem(...).render_brief()``. It keeps context windows small while
+    still exposing problem IDs, titles, kinds, taxonomy, tags, and capability
+    flags needed for routing.
+
+    Args:
+        tags: Tags that must all be present on a matching entry.
+        text: Case-insensitive free-text search term.
+        feature_flags: Feature flags that must all be present on a matching entry.
+        kind: Optional problem-family filter as a ``ProblemKind`` or string value.
+        capabilities: Capability flags that must all be present.
+        study_suitability: Study-suitability flags that must all be present.
+
+    Returns:
+        Compact summaries for matching entries in deterministic order.
+
+    Raises:
+        ValueError: If ``kind`` is a string that is not a known problem kind.
+    """
+    return _DEFAULT_REGISTRY.summaries(
+        tags=tags,
+        text=text,
+        feature_flags=feature_flags,
+        kind=_coerce_problem_kind(kind),
+        capabilities=capabilities,
+        study_suitability=study_suitability,
+    )
 
 
 @overload

--- a/src/design_research_problems/problems/__init__.py
+++ b/src/design_research_problems/problems/__init__.py
@@ -14,7 +14,15 @@ from ._decision import (
 )
 from ._grammar import GrammarProblem, GrammarTransition
 from ._mcp_problem import MCPProblem
-from ._metadata import Citation, ProblemAsset, ProblemBenchmarkCard, ProblemKind, ProblemMetadata, ProblemTaxonomy
+from ._metadata import (
+    Citation,
+    ProblemAsset,
+    ProblemBenchmarkCard,
+    ProblemCatalogSummary,
+    ProblemKind,
+    ProblemMetadata,
+    ProblemTaxonomy,
+)
 from ._optimization import OptimizationEvaluation, OptimizationProblem
 from ._problem import Problem
 from ._text import TextProblem
@@ -39,6 +47,7 @@ __all__ = [
     "Problem",
     "ProblemAsset",
     "ProblemBenchmarkCard",
+    "ProblemCatalogSummary",
     "ProblemKind",
     "ProblemMetadata",
     "ProblemTaxonomy",

--- a/src/design_research_problems/problems/_metadata.py
+++ b/src/design_research_problems/problems/_metadata.py
@@ -178,6 +178,83 @@ class ProblemMetadata:
         return normalized in self.feature_flags
 
 
+@dataclass(frozen=True)
+class ProblemCatalogSummary:
+    """Compact problem metadata for search results and agent context windows."""
+
+    problem_id: str
+    """Stable catalog identifier."""
+    title: str
+    """Display title shown to users."""
+    kind: ProblemKind
+    """High-level problem family."""
+    summary: str
+    """Short one-paragraph problem description."""
+    tags: tuple[str, ...]
+    """Searchable descriptive tags."""
+    formulation: str | None
+    """High-level mathematical or representational formulation."""
+    design_variable_type: str | None
+    """Variable domain such as continuous, discrete, or mixed."""
+    objective_mode: str | None
+    """Objective structure such as single, multi, or qualitative."""
+    constraint_nature: str | None
+    """Constraint strictness label such as hard, soft, or informal."""
+    bounds_summary: str | None
+    """Human-readable summary of bounds or design-space limits."""
+    capabilities: tuple[str, ...]
+    """Machine-readable implementation and packaging capabilities."""
+    study_suitability: tuple[str, ...]
+    """Machine-readable study-use labels for the entry."""
+
+    @classmethod
+    def from_metadata(cls, metadata: ProblemMetadata) -> ProblemCatalogSummary:
+        """Build a compact summary from one full metadata record.
+
+        Args:
+            metadata: Full problem metadata.
+
+        Returns:
+            Compact catalog summary suitable for search results.
+        """
+        taxonomy = metadata.taxonomy
+        return cls(
+            problem_id=metadata.problem_id,
+            title=metadata.title,
+            kind=metadata.kind,
+            summary=metadata.summary,
+            tags=taxonomy.tags,
+            formulation=taxonomy.formulation,
+            design_variable_type=taxonomy.design_variable_type,
+            objective_mode=taxonomy.objective_mode,
+            constraint_nature=taxonomy.constraint_nature,
+            bounds_summary=taxonomy.bounds_summary,
+            capabilities=metadata.capabilities,
+            study_suitability=metadata.study_suitability,
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-compatible summary dictionary.
+
+        Returns:
+            Dictionary form with enum values normalized to strings.
+        """
+        return {
+            "problem_id": self.problem_id,
+            "title": self.title,
+            "kind": self.kind.value,
+            "summary": self.summary,
+            "tags": list(self.tags),
+            "formulation": self.formulation,
+            "design_variable_type": self.design_variable_type,
+            "objective_mode": self.objective_mode,
+            "constraint_nature": self.constraint_nature,
+            "bounds_summary": self.bounds_summary,
+            "capabilities": list(self.capabilities),
+            "study_suitability": list(self.study_suitability),
+        }
+
+
 KNOWN_PROBLEM_CAPABILITIES = frozenset(
     {
         "statement-markdown",

--- a/src/design_research_problems/problems/_optimization.py
+++ b/src/design_research_problems/problems/_optimization.py
@@ -96,6 +96,44 @@ class LocalSearchResult:
     """Number of objective evaluations performed."""
 
 
+def _recommended_solver_family(
+    *,
+    variable_domain: str | None,
+    constraint_nature: str | None,
+    equality_constraints: int,
+    inequality_constraints: int,
+    is_dynamic: bool,
+) -> str:
+    """Return a compact solver-family hint from catalog taxonomy.
+
+    Args:
+        variable_domain: Taxonomy variable-domain label.
+        constraint_nature: Taxonomy constraint label.
+        equality_constraints: Number of equality constraints.
+        inequality_constraints: Number of inequality constraints.
+        is_dynamic: Whether the problem changes during evaluation.
+
+    Returns:
+        Human-readable solver-family hint for routing agents.
+    """
+    domain = (variable_domain or "").lower()
+    constraint_label = (constraint_nature or "").lower()
+    has_explicit_constraints = equality_constraints > 0 or inequality_constraints > 0
+    has_hard_constraints = has_explicit_constraints or "hard" in constraint_label
+
+    if is_dynamic:
+        return "dynamic or evaluation-aware optimization; avoid assuming a stationary objective"
+    if domain == "continuous" and has_hard_constraints:
+        return "constrained continuous optimizer such as SLSQP or trust-constr"
+    if domain == "continuous":
+        return "bounded continuous optimizer or deterministic local search"
+    if domain == "discrete":
+        return "discrete or combinatorial optimizer; preserve integrality explicitly"
+    if domain == "mixed":
+        return "mixed-domain optimizer or decomposition; preserve discrete variables explicitly"
+    return "inspect metadata and problem API before selecting a solver"
+
+
 def bounded_pattern_search(
     objective: Callable[[NDArray[numpy.float64]], float],
     lower_bounds: NDArray[numpy.float64],
@@ -181,6 +219,43 @@ class OptimizationProblem(ComputableProblem[NDArray[numpy.float64], Optimization
         )
         self.constraints: list[ConstraintDefinition] = []
 
+    def solver_hints(self) -> dict[str, object]:
+        """Return compact optimization hints for solver selection.
+
+        The hints summarize machine-readable bounds, variable domain, and
+        constraint counts so an agent does not have to infer solver class from
+        prose in the design brief.
+
+        Returns:
+            JSON-compatible solver-selection hints.
+        """
+        taxonomy = self.metadata.taxonomy
+        equality_constraints = sum(1 for constraint in self.constraints if constraint.kind == "eq")
+        inequality_constraints = sum(1 for constraint in self.constraints if constraint.kind == "ineq")
+        benchmark_card = self.metadata.benchmark_card
+        return {
+            "problem_id": self.metadata.problem_id,
+            "problem_kind": self.metadata.kind.value,
+            "variable_count": int(self.bounds.lb.shape[0]),
+            "variable_domain": taxonomy.design_variable_type,
+            "lower_bounds": to_json_value(self.bounds.lb),
+            "upper_bounds": to_json_value(self.bounds.ub),
+            "bounds_summary": taxonomy.bounds_summary,
+            "objective_mode": taxonomy.objective_mode,
+            "constraint_nature": taxonomy.constraint_nature,
+            "equality_constraint_count": equality_constraints,
+            "inequality_constraint_count": inequality_constraints,
+            "is_dynamic": taxonomy.is_dynamic,
+            "baseline_solver_role": None if benchmark_card is None else benchmark_card.solver_role,
+            "recommended_solver_family": _recommended_solver_family(
+                variable_domain=taxonomy.design_variable_type,
+                constraint_nature=taxonomy.constraint_nature,
+                equality_constraints=equality_constraints,
+                inequality_constraints=inequality_constraints,
+                is_dynamic=taxonomy.is_dynamic,
+            ),
+        }
+
     def evaluate(self, variables: NDArray[numpy.float64]) -> OptimizationEvaluation:
         """Evaluate one candidate vector without invoking the solver.
 
@@ -260,11 +335,25 @@ class OptimizationProblem(ComputableProblem[NDArray[numpy.float64], Optimization
                 "report": report,
             }
 
+        def solver_hints() -> dict[str, object]:
+            """Return variable-domain and constraint hints for solver selection.
+
+            Returns:
+                MCP-ready solver-selection hints.
+            """
+            return self.solver_hints()
+
         server.add_tool(
             evaluate_tool,
             name="evaluate",
             title="Evaluate Design",
             description="Evaluate a candidate vector and return feasibility/objective metrics.",
+        )
+        server.add_tool(
+            solver_hints,
+            name="solver_hints",
+            title="Get Solver Hints",
+            description="Return variable-domain, bounds, and constraint hints for choosing a solver.",
         )
         server.add_tool(
             submit_final,

--- a/tests/test_mcp_servers.py
+++ b/tests/test_mcp_servers.py
@@ -117,9 +117,14 @@ def test_optimization_problem_to_mcp_server_exposes_evaluate_and_submit_final(
 
     server = problem.to_mcp_server()
     assert "problem://design-brief" in _resource_uris(server)
-    assert {"evaluate", "submit_final"}.issubset(_tool_names(server))
+    assert {"evaluate", "solver_hints", "submit_final"}.issubset(_tool_names(server))
 
     candidate = problem.generate_initial_solution(seed=3).tolist()
+    hints = _call_tool_json(server, "solver_hints", {})
+    assert hints["variable_domain"] == "continuous"
+    assert hints["equality_constraint_count"] == 1
+    assert hints["recommended_solver_family"] == "constrained continuous optimizer such as SLSQP or trust-constr"
+
     report = _call_tool_json(server, "evaluate", {"x": candidate})
     assert report["evaluation"]["is_feasible"] is True
     assert report["objective_components"]["sum"] == pytest.approx(sum(candidate))

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -12,6 +12,7 @@ EXPECTED_PUBLIC_API = [
     "ComputableProblem",
     "ProblemKind",
     "ProblemMetadata",
+    "ProblemCatalogSummary",
     "ProblemTaxonomy",
     "Citation",
     "ProblemAsset",
@@ -35,6 +36,7 @@ EXPECTED_PUBLIC_API = [
     "get_problem",
     "get_problem_as",
     "list_problems",
+    "search_problem_summaries",
     "get_ideation_catalog",
     "integration",
 ]

--- a/tests/test_registry_and_problems.py
+++ b/tests/test_registry_and_problems.py
@@ -22,10 +22,12 @@ from design_research_problems import (
     OptimizationEvaluation,
     OptimizationProblem,
     Problem,
+    ProblemCatalogSummary,
     ProblemEvaluationError,
     ProblemKind,
     get_problem,
     list_problems,
+    search_problem_summaries,
 )
 from design_research_problems.problems import DecisionOption
 from design_research_problems.problems._domains.battery_cell_model import BatteryBackendConfig, BatteryCellModel
@@ -458,6 +460,28 @@ def test_registry_search_filters_by_feature_flags() -> None:
         "ideation_remote_village_rainwater_access",
         "ideation_snow_transport_for_novices",
     ]
+
+
+def test_registry_exposes_compact_problem_summaries_for_agent_selection() -> None:
+    from design_research_problems import ProblemRegistry
+
+    registry = ProblemRegistry()
+    summaries = registry.summaries(text="pill", kind=ProblemKind.OPTIMIZATION)
+
+    assert summaries
+    assert all(isinstance(summary, ProblemCatalogSummary) for summary in summaries)
+    pill_summary = next(summary for summary in summaries if summary.problem_id == "pill_capsule_min_area")
+    assert pill_summary.kind is ProblemKind.OPTIMIZATION
+    assert pill_summary.design_variable_type == "continuous"
+    assert pill_summary.bounds_summary == "radius and length bounded on [0, 1]"
+    assert "baseline-solver" in pill_summary.capabilities
+    assert pill_summary.to_dict()["kind"] == "optimization"
+    assert "statement" not in pill_summary.to_dict()
+
+    top_level_summaries = search_problem_summaries(text="peanut", kind="text")
+    top_level_ids = [summary.problem_id for summary in top_level_summaries]
+    assert "ideation_peanut_shelling" in top_level_ids
+    assert "ideation_peanut_shelling_fu_cagan_kotovsky_2010" in top_level_ids
 
 
 def test_pill_helpers_return_expected_positive_values() -> None:
@@ -939,6 +963,21 @@ def test_pill_problem_evaluate_returns_standardized_optimization_evaluation() ->
     assert evaluation.total_constraint_violation == pytest.approx(problem.constraint_violation(candidate))
     assert evaluation.max_constraint_violation == pytest.approx(problem.max_constraint_violation(candidate))
     assert evaluation.is_feasible is True
+
+
+def test_pill_problem_exposes_solver_hints_without_parsing_brief_prose() -> None:
+    problem = get_problem("pill_capsule_min_area")
+    hints = problem.solver_hints()
+
+    assert hints["problem_id"] == "pill_capsule_min_area"
+    assert hints["problem_kind"] == "optimization"
+    assert hints["variable_count"] == 2
+    assert hints["variable_domain"] == "continuous"
+    assert hints["lower_bounds"] == [0.0, 0.0]
+    assert hints["upper_bounds"] == [1.0, 1.0]
+    assert hints["equality_constraint_count"] == 1
+    assert hints["inequality_constraint_count"] == 0
+    assert hints["recommended_solver_family"] == "constrained continuous optimizer such as SLSQP or trust-constr"
 
 
 def test_pill_problem_seeded_initial_solution_stays_within_bounds() -> None:


### PR DESCRIPTION
## Summary

- Add `ProblemCatalogSummary` and `search_problem_summaries(...)` so agents can select catalog tasks without loading full briefs.
- Add `OptimizationProblem.solver_hints()` and expose the same payload through the optimization MCP `solver_hints` tool.
- Update public API docs, quickstart guidance, optimization docs, and focused tests.

## Validation

- `.venv/bin/python -m ruff check src/design_research_problems/__init__.py src/design_research_problems/_catalog/__init__.py src/design_research_problems/_catalog/_registry.py src/design_research_problems/problems/__init__.py src/design_research_problems/problems/_metadata.py src/design_research_problems/problems/_optimization.py tests/test_mcp_servers.py tests/test_public_api.py tests/test_registry_and_problems.py`
- `.venv/bin/python -m ruff format --check src/design_research_problems/__init__.py src/design_research_problems/_catalog/__init__.py src/design_research_problems/_catalog/_registry.py src/design_research_problems/problems/__init__.py src/design_research_problems/problems/_metadata.py src/design_research_problems/problems/_optimization.py tests/test_mcp_servers.py tests/test_public_api.py tests/test_registry_and_problems.py`
- `PYTHONPATH=src .venv/bin/python -m pytest -q tests/test_registry_and_problems.py tests/test_mcp_servers.py tests/test_public_api.py`
- `.venv/bin/python -m mypy src`
- `.venv/bin/python scripts/generate_problem_catalog_docs.py --check`
- `.venv/bin/python scripts/check_docs_consistency.py`