### PR TITLE
[codex] Document VS Code start path for problems

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,39 +67,19 @@ merging.
 - Keep the base install lean and avoid introducing optional-dependency behavior
   into default test paths.
 
-## Release Naming
+## Release Planning
 
-- Theme: endangered species.
-- Monthly work-cycle names are shared across milestone titles, release PR
-  titles, and release branches.
-- Name the cycle for the month the work is done, not the later drop month.
-  - Milestone title / PR title: `{base name} - {Work month YYYY}`
-  - Release branch: slugified full title, for example
-    `monarch-maze-april-2026`
-- Milestone due dates should land in the first week of the following month.
-- Milestone descriptions must use:
-  - `Work month: {Month YYYY}.`
-  - `Theme source: <url>`
-- Release PR bodies must repeat the same `Theme source:` link used on the
-  milestone and refer to the same work month named in the title.
-- Never reuse an exact base name or the same primary subject across any work
-  month or any of the four design-research module repos unless all four
-  `AGENTS.md` files are intentionally updated together.
-- Before adding a new release name, check the `Release Naming` tables in all
-  four repos to avoid repeats.
-
-| Work month | Target drop | Base name | Source subject |
-| --- | --- | --- | --- |
-| March 2026 | April 1, 2026 | Axolotl Array | Axolotl |
-| April 2026 | May 1, 2026 | Monarch Maze | Monarch butterfly |
-| May 2026 | June 1, 2026 | Jaguar Junction | Jaguar |
-| June 2026 | July 1, 2026 | Saola Sandbox | Saola |
-| July 2026 | August 1, 2026 | Orangutan Obstacle | Orangutan |
-| August 2026 | September 1, 2026 | Numbat Nexus | Numbat |
-| September 2026 | October 1, 2026 | Dhole Dilemma | Dhole |
-| October 2026 | November 1, 2026 | Kakapo Knot | Kakapo |
-| November 2026 | December 1, 2026 | Vaquita Vault | Vaquita |
-| December 2026 | January 1, 2027 | Pangolin Puzzle | Pangolin |
+- Do not create monthly milestone naming tables, themed release PR names, or
+  calendar release branches as default maintenance.
+- Prefer small issue/PR-scoped planning and package version releases driven by
+  user-facing changes.
+- Use GitHub milestones only for explicit, short-lived initiatives with an
+  active owner; they are optional scheduling aids, not release gates.
+- Name release branches and release PRs for the version or concrete change set
+  they contain.
+- When publishing, update package metadata, docs, examples, and GitHub
+  Releases/PyPI notes as needed. Do not add README callouts that point to
+  monthly milestones.
 ## Keep This File Up To Date
 
 Update this file whenever contributor workflow changes, especially when setup

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,10 @@ source .venv/bin/activate
 make dev
 ```
 
+If you are opening the project in VS Code, follow
+`docs/vscode_start.rst` for interpreter selection, optional extras, first
+checks, and troubleshooting.
+
 Optional integration setup for problem families that require external backends:
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,9 +8,9 @@ source .venv/bin/activate
 make dev
 ```
 
-If you are opening the project in VS Code, follow
-`docs/vscode_start.rst` for interpreter selection, optional extras, first
-checks, and troubleshooting.
+If you are opening the project in VS Code, follow `docs/vscode_start.rst` for
+the PyPI install path, source checkout path, interpreter selection, optional
+extras, first checks, and troubleshooting.
 
 Optional integration setup for problem families that require external backends:
 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,6 @@
 [![PyPI Version](https://img.shields.io/pypi/v/design-research-problems.svg)](https://pypi.org/project/design-research-problems/)
 [![Python Versions](https://img.shields.io/pypi/pyversions/design-research-problems.svg)](https://pypi.org/project/design-research-problems/)
 
-<!-- release-callout:start -->
-> [!IMPORTANT]
-> Current monthly release: [Jaguar Junction - May 2026](https://github.com/cmudrc/design-research-problems/milestone/3)  
-> Due: June 1, 2026  
-> Tracks: May 2026 work
-<!-- release-callout:end -->
-
 `design-research-problems` is a compact library and compendium of design research
 problems. It packages canonical research prompts, optimization benchmarks, and
 discrete grammar-style problems behind a small, typed Python API.

--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ for runnable examples across all problem families.
 See the [published documentation](https://cmudrc.github.io/design-research-problems/)
 for quickstart, problem-family guides, generated catalog pages, and API reference.
 
+Opening the repo in VS Code? Start with the
+[VS Code setup guide](https://cmudrc.github.io/design-research-problems/vscode_start.html).
+
 Build docs locally with:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -105,8 +105,9 @@ for runnable examples across all problem families.
 See the [published documentation](https://cmudrc.github.io/design-research-problems/)
 for quickstart, problem-family guides, generated catalog pages, and API reference.
 
-Opening the repo in VS Code? Start with the
-[VS Code setup guide](https://cmudrc.github.io/design-research-problems/vscode_start.html).
+Using VS Code? Start with the
+[VS Code example guide](https://cmudrc.github.io/design-research-problems/vscode_start.html)
+for a PyPI install path and source checkout example path.
 
 Build docs locally with:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -80,6 +80,7 @@ a stable problem-research pipeline.
 
 - :doc:`quickstart`
 - :doc:`installation`
+- :doc:`vscode_start`
 - :doc:`concepts`
 - :doc:`catalog_guide`
 - :doc:`typical_workflow`
@@ -149,6 +150,7 @@ Start Here
 
    quickstart
    installation
+   vscode_start
    concepts
    catalog_guide
    typical_workflow

--- a/docs/vscode_start.rst
+++ b/docs/vscode_start.rst
@@ -1,0 +1,146 @@
+VS Code Start
+=============
+
+Use this path when opening ``design-research-problems`` in VS Code for the
+first time. The commands are repo-local and assume Python 3.12 or newer.
+
+Requirements
+------------
+
+- Python 3.12 or newer. Maintainer workflows target the version in
+  ``.python-version``.
+- VS Code with the Python extension.
+- ``make`` available in the integrated terminal.
+- Optional: ``uv`` for faster virtual environment and package installs.
+
+Open the Repository
+-------------------
+
+Open the repository root folder in VS Code, not the parent ecosystem folder. The
+root should contain ``pyproject.toml``, ``Makefile``, ``src/``, ``tests/``, and
+``examples/``.
+
+Create an Environment
+---------------------
+
+Standard library setup:
+
+.. code-block:: bash
+
+   python -m venv .venv
+   source .venv/bin/activate
+
+On Windows PowerShell, use:
+
+.. code-block:: powershell
+
+   py -3.12 -m venv .venv
+   .venv\Scripts\Activate.ps1
+
+With ``uv``:
+
+.. code-block:: bash
+
+   uv venv --python 3.12
+   source .venv/bin/activate
+
+Install Development Dependencies
+--------------------------------
+
+Use the maintainer shortcut:
+
+.. code-block:: bash
+
+   make dev
+
+Equivalent ``pip`` command:
+
+.. code-block:: bash
+
+   python -m pip install --upgrade pip setuptools wheel
+   python -m pip install -e ".[dev]"
+
+Equivalent ``uv`` command:
+
+.. code-block:: bash
+
+   uv pip install -e ".[dev]"
+
+Install optional extras only when the problem family or backend needs them:
+
+.. code-block:: bash
+
+   python -m pip install -e ".[grammar]"
+   python -m pip install -e ".[battery]"
+   python -m pip install -e ".[mcp,cad]"
+   python -m pip install -e ".[solvers,pandas]"
+
+Use ``make dev-full`` when you need the broadest local validation environment.
+
+Select the VS Code Interpreter
+------------------------------
+
+Run ``Python: Select Interpreter`` from the command palette and choose the
+interpreter inside ``.venv``. If VS Code does not list it, enter the interpreter
+path manually:
+
+- macOS/Linux: ``.venv/bin/python``
+- Windows: ``.venv\Scripts\python.exe``
+
+First Checks
+------------
+
+Run the checks from VS Code's integrated terminal:
+
+.. code-block:: bash
+
+   make test
+   make qa
+   make docs-check
+
+``make qa`` runs linting, formatting checks, type checks, and tests. Run
+``make coverage`` before merge when changing tested behavior.
+
+Problem Families And Optional Backends
+--------------------------------------
+
+The base install covers text, decision, catalog, and SciPy-backed optimization
+workflows. Install optional extras only for workflows that need them:
+
+- ``grammar`` for truss-oriented grammar and structural workflows.
+- ``battery`` for battery grammar and battery optimization workflows.
+- ``mcp,cad`` for MCP-backed CAD task workflows.
+- ``solvers,pandas`` for external optimizer backends and tabular exports.
+
+External simulators and solver toolchains should stay out of the default setup
+unless the issue or example explicitly requires them.
+
+Deterministic Examples
+----------------------
+
+Run the compact deterministic example path from the integrated terminal:
+
+.. code-block:: bash
+
+   make examples-smoke
+
+To run catalog examples directly:
+
+.. code-block:: bash
+
+   PYTHONPATH=src python examples/catalog/list_and_load.py
+   PYTHONPATH=src python examples/catalog/public_api_tour.py
+
+Troubleshooting
+---------------
+
+- If VS Code imports fail but the terminal works, reselect the ``.venv``
+  interpreter and reload the window.
+- If ``make`` uses the wrong Python, activate ``.venv`` in the terminal or run
+  ``PYTHON=.venv/bin/python make test``.
+- If Windows activation is blocked, enable script execution for the current
+  user or use the VS Code Python extension's environment activation.
+- If an optional backend import is missing, install the matching family extra
+  rather than ``all`` unless you need broad validation coverage.
+- Avoid committing generated runtime output under ``artifacts/``,
+  ``docs/_build/``, or local virtual environment directories.

--- a/docs/vscode_start.rst
+++ b/docs/vscode_start.rst
@@ -1,8 +1,13 @@
-VS Code Start
-=============
+Run An Example In VS Code
+=========================
 
-Use this path when opening ``design-research-problems`` in VS Code for the
-first time. The commands are repo-local and assume Python 3.12 or newer.
+Use this page when you want to try ``design-research-problems`` in VS Code.
+Choose the installed-package path for a first user workflow, or the source
+checkout path when you want to run the repository's checked-in examples and
+development checks.
+
+The checked-in ``examples/`` directory lives in the repository source. Do not
+assume those files are present inside the PyPI wheel.
 
 Requirements
 ------------
@@ -10,75 +15,31 @@ Requirements
 - Python 3.12 or newer. Maintainer workflows target the version in
   ``.python-version``.
 - VS Code with the Python extension.
-- ``make`` available in the integrated terminal.
-- Optional: ``uv`` for faster virtual environment and package installs.
+- A VS Code integrated terminal.
 
-Open the Repository
--------------------
+Installed Package From PyPI
+---------------------------
 
-Open the repository root folder in VS Code, not the parent ecosystem folder. The
-root should contain ``pyproject.toml``, ``Makefile``, ``src/``, ``tests/``, and
-``examples/``.
+Open an empty folder in VS Code, then create and activate a virtual
+environment from ``Terminal > New Terminal``.
 
-Create an Environment
----------------------
-
-Standard library setup:
+On macOS or Linux:
 
 .. code-block:: bash
 
    python -m venv .venv
    source .venv/bin/activate
+   python -m pip install --upgrade pip
+   python -m pip install design-research-problems
 
-On Windows PowerShell, use:
+On Windows PowerShell:
 
 .. code-block:: powershell
 
    py -3.12 -m venv .venv
-   .venv\Scripts\Activate.ps1
-
-With ``uv``:
-
-.. code-block:: bash
-
-   uv venv --python 3.12
-   source .venv/bin/activate
-
-Install Development Dependencies
---------------------------------
-
-Use the maintainer shortcut:
-
-.. code-block:: bash
-
-   make dev
-
-Equivalent ``pip`` command:
-
-.. code-block:: bash
-
-   python -m pip install --upgrade pip setuptools wheel
-   python -m pip install -e ".[dev]"
-
-Equivalent ``uv`` command:
-
-.. code-block:: bash
-
-   uv pip install -e ".[dev]"
-
-Install optional extras only when the problem family or backend needs them:
-
-.. code-block:: bash
-
-   python -m pip install -e ".[grammar]"
-   python -m pip install -e ".[battery]"
-   python -m pip install -e ".[mcp,cad]"
-   python -m pip install -e ".[solvers,pandas]"
-
-Use ``make dev-full`` when you need the broadest local validation environment.
-
-Select the VS Code Interpreter
-------------------------------
+   .\.venv\Scripts\Activate.ps1
+   python -m pip install --upgrade pip
+   python -m pip install design-research-problems
 
 Run ``Python: Select Interpreter`` from the command palette and choose the
 interpreter inside ``.venv``. If VS Code does not list it, enter the interpreter
@@ -87,8 +48,53 @@ path manually:
 - macOS/Linux: ``.venv/bin/python``
 - Windows: ``.venv\Scripts\python.exe``
 
-First Checks
-------------
+Create ``problems_example.py`` in the workspace folder:
+
+.. code-block:: python
+
+   import design_research_problems as derp
+
+   print(f"Catalog size: {len(derp.list_problems())}")
+   problem = derp.get_problem("ideation_peanut_shelling_fu_cagan_kotovsky_2010")
+   print(problem.render_brief(include_citation=False))
+
+Run the file with VS Code's ``Run Python File`` action, or run:
+
+.. code-block:: bash
+
+   python problems_example.py
+
+Source Checkout For Repository Examples
+---------------------------------------
+
+Use this path when you want the checked-in examples, docs, tests, and optional
+development tooling.
+
+.. code-block:: bash
+
+   git clone https://github.com/cmudrc/design-research-problems.git
+   cd design-research-problems
+   python -m venv .venv
+   source .venv/bin/activate
+   python -m pip install --upgrade pip setuptools wheel
+   python -m pip install -e ".[dev]"
+
+Equivalent maintainer shortcut:
+
+.. code-block:: bash
+
+   make dev
+
+Run the compact deterministic example path from the integrated terminal:
+
+.. code-block:: bash
+
+   make examples-smoke
+   python examples/catalog/list_and_load.py
+   python examples/catalog/public_api_tour.py
+
+First Development Checks
+------------------------
 
 Run the checks from VS Code's integrated terminal:
 
@@ -101,35 +107,21 @@ Run the checks from VS Code's integrated terminal:
 ``make qa`` runs linting, formatting checks, type checks, and tests. Run
 ``make coverage`` before merge when changing tested behavior.
 
-Problem Families And Optional Backends
---------------------------------------
+Optional Backends
+-----------------
 
 The base install covers text, decision, catalog, and SciPy-backed optimization
 workflows. Install optional extras only for workflows that need them:
 
-- ``grammar`` for truss-oriented grammar and structural workflows.
-- ``battery`` for battery grammar and battery optimization workflows.
-- ``mcp,cad`` for MCP-backed CAD task workflows.
-- ``solvers,pandas`` for external optimizer backends and tabular exports.
-
-External simulators and solver toolchains should stay out of the default setup
-unless the issue or example explicitly requires them.
-
-Deterministic Examples
-----------------------
-
-Run the compact deterministic example path from the integrated terminal:
-
 .. code-block:: bash
 
-   make examples-smoke
+   python -m pip install -e ".[grammar]"
+   python -m pip install -e ".[battery]"
+   python -m pip install -e ".[mcp,cad]"
+   python -m pip install -e ".[solvers,pandas]"
 
-To run catalog examples directly:
-
-.. code-block:: bash
-
-   PYTHONPATH=src python examples/catalog/list_and_load.py
-   PYTHONPATH=src python examples/catalog/public_api_tour.py
+Use ``make dev-full`` only when you need the broadest local validation
+environment.
 
 Troubleshooting
 ---------------
@@ -138,8 +130,8 @@ Troubleshooting
   interpreter and reload the window.
 - If ``make`` uses the wrong Python, activate ``.venv`` in the terminal or run
   ``PYTHON=.venv/bin/python make test``.
-- If Windows activation is blocked, enable script execution for the current
-  user or use the VS Code Python extension's environment activation.
+- If Windows activation is blocked, switch the terminal profile to Command
+  Prompt and run ``.\.venv\Scripts\activate.bat``.
 - If an optional backend import is missing, install the matching family extra
   rather than ``all`` unless you need broad validation coverage.
 - Avoid committing generated runtime output under ``artifacts/``,


### PR DESCRIPTION
## Summary
- make the VS Code guide start with a PyPI install path and pasteable public-API example
- keep a separate source checkout path for repository examples, dev dependencies, checks, and optional backends
- update README and CONTRIBUTING links so the PyPI/source split is visible from the first-run path
- remove the README monthly release callout and AGENTS monthly release naming table
- keep future release planning issue/PR-scoped, with GitHub milestones treated as optional short-lived aids rather than release gates

Closes #82
Refs cmudrc/design-research#22

## Verification
- PyPI smoke-tested the documented starter snippets in a clean virtualenv
- `make docs-check`
- `make docs-build`