### PR TITLE
[codex] Prepare design-research-problems 0.4.0

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,5 @@
 [run]
+patch = subprocess
 omit =
     src/design_research_problems/gui/iot_home_cooling_tk.py
     src/design_research_problems/gui/truss_analysis_program_tk.py

--- a/.github/badges/coverage.svg
+++ b/.github/badges/coverage.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="116" 
-    height="20" role="img" aria-label="Test Coverage: 90%">
+    height="20" role="img" aria-label="Test Coverage: 95%">
   <linearGradient id="g" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
     <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
@@ -18,7 +18,7 @@
   font-size="11">
     <text x="44.0" y="15" fill="#010101" fill-opacity=".3">Test Coverage</text>
     <text x="44.0" y="14">Test Coverage</text>
-    <text x="102.0" y="15" fill="#010101" fill-opacity=".3">90%</text>
-    <text x="102.0" y="14">90%</text>
+    <text x="102.0" y="15" fill="#010101" fill-opacity=".3">95%</text>
+    <text x="102.0" y="14">95%</text>
   </g>
 </svg>

--- a/.github/badges/examples-api-coverage.svg
+++ b/.github/badges/examples-api-coverage.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="170" 
-    height="20" role="img" aria-label="Example API Coverage: 28/29">
+<svg xmlns="http://www.w3.org/2000/svg" width="140"
+    height="20" role="img" aria-label="API in Examples: 32/32">
   <linearGradient id="g" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
     <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
@@ -7,18 +7,18 @@
     <stop offset="1" stop-opacity=".5"/>
   </linearGradient>
   <clipPath id="r">
-    <rect width="170" height="20" rx="3" fill="#fff"/>
+    <rect width="140" height="20" rx="3" fill="#fff"/>
   </clipPath>
   <g clip-path="url(#r)">
-    <rect width="130" height="20" fill="#555"/>
-    <rect x="130" width="40" height="20" fill="#4c1"/>
-    <rect width="170" height="20" fill="url(#g)"/>
+    <rect width="100" height="20" fill="#555"/>
+    <rect x="100" width="40" height="20" fill="#4c1"/>
+    <rect width="140" height="20" fill="url(#g)"/>
   </g>
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" 
   font-size="11">
-    <text x="65.0" y="15" fill="#010101" fill-opacity=".3">Example API Coverage</text>
-    <text x="65.0" y="14">Example API Coverage</text>
-    <text x="150.0" y="15" fill="#010101" fill-opacity=".3">28/29</text>
-    <text x="150.0" y="14">28/29</text>
+    <text x="50.0" y="15" fill="#010101" fill-opacity=".3">API in Examples</text>
+    <text x="50.0" y="14">API in Examples</text>
+    <text x="120.0" y="15" fill="#010101" fill-opacity=".3">32/32</text>
+    <text x="120.0" y="14">32/32</text>
   </g>
 </svg>

--- a/.github/badges/examples-passing.svg
+++ b/.github/badges/examples-passing.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="146" 
+<svg xmlns="http://www.w3.org/2000/svg" width="146"
     height="20" role="img" aria-label="Examples Passing: 36/36">
   <linearGradient id="g" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7"/>

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,58 +1,97 @@
 name: Publish
 
 on:
-  push:
-    tags:
-      - "v*"
+  release:
+    types: [published]
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish the validated artifacts to PyPI
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: read
 
+concurrency:
+  group: publish-${{ github.event.release.tag_name || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
-    name: Build distributions
+    name: Build and validate distributions
     runs-on: ubuntu-latest
+
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - name: Check out release source
+        uses: actions/checkout@v5
+
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
-      - name: Verify tag matches package version
+
+      - name: Verify publishing tag matches package version
         env:
-          GITHUB_REF_TYPE: ${{ github.ref_type }}
-          GITHUB_REF_NAME: ${{ github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
+          MANUAL_PUBLISH: ${{ inputs.publish }}
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           python - <<'PY'
           import os
           import pathlib
           import tomllib
 
-          version = tomllib.loads(pathlib.Path("pyproject.toml").read_text(encoding="utf-8"))["project"]["version"]
-          if os.environ["GITHUB_REF_TYPE"] == "tag":
-              expected = f"v{version}"
-              actual = os.environ["GITHUB_REF_NAME"]
-              if actual != expected:
-                  raise SystemExit(f"Tag {actual!r} does not match pyproject version {expected!r}.")
-          print(f"Preparing release for design-research-problems {version}.")
+          package_name = "design-research-problems"
+          project = tomllib.loads(
+              pathlib.Path("pyproject.toml").read_text(encoding="utf-8")
+          )["project"]
+          expected_tag = f"v{project['version']}"
+          event_name = os.environ["EVENT_NAME"]
+          manual_publish = os.environ.get("MANUAL_PUBLISH", "").lower() == "true"
+
+          if event_name == "release":
+              actual_tag = os.environ["RELEASE_TAG"]
+          elif manual_publish:
+              if os.environ["REF_TYPE"] != "tag":
+                  raise SystemExit(
+                      "Manual publishing must be dispatched from the release tag, "
+                      f"not {os.environ['REF_TYPE']} {os.environ['REF_NAME']!r}."
+                  )
+              actual_tag = os.environ["REF_NAME"]
+          else:
+              actual_tag = None
+
+          if actual_tag is not None and actual_tag != expected_tag:
+              raise SystemExit(
+                  f"Tag {actual_tag!r} does not match package version {expected_tag!r}."
+              )
+
+          mode = "publish" if actual_tag is not None else "build-only"
+          print(f"Preparing {package_name} {project['version']} ({mode}).")
           PY
-      - name: Install build tools
+
+      - name: Install release tooling
         run: python -m pip install --upgrade pip build twine
-      - name: Build distribution artifacts
+
+      - name: Build and validate distribution artifacts
         run: make release-check
+
       - name: Upload distribution artifacts
         uses: actions/upload-artifact@v4
         with:
           name: python-package-distributions
           path: dist/*
+          if-no-files-found: error
 
   publish:
-    name: Publish to PyPI
+    name: Publish distributions to PyPI
     needs: build
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'release' || inputs.publish == true
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -60,12 +99,14 @@ jobs:
     permissions:
       contents: read
       id-token: write
+
     steps:
       - name: Download distribution artifacts
         uses: actions/download-artifact@v4
         with:
           name: python-package-distributions
           path: dist
+
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -42,8 +42,7 @@ pip-delete-this-directory.txt
 htmlcov/
 .tox/
 .nox/
-.coverage
-.coverage.*
+.coverage*
 .cache
 artifacts/
 nosetests.xml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,18 @@ make install-pybamm    # battery grammar + battery optimization families
 make dev-full          # install dev + all optional extras
 ```
 
+## Release Publishing
+
+Before cutting a release, run `make release-check`. The GitHub `Publish`
+workflow builds and validates distributions before any upload:
+
+- Publishing a GitHub Release tagged `v{package-version}` publishes to PyPI.
+- A manual workflow run is build-only by default.
+- A recovery publish requires selecting the release tag and explicitly setting
+  `publish=true`; publishing from a branch is rejected.
+- Every publishing path rejects a tag that differs from the version in
+  `pyproject.toml`.
+
 ## Local Quality Checks
 
 Run these before opening a pull request:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,12 @@ make docs-check
 make ci
 ```
 
+## Quality Gates
+
+- `make coverage` enforces at least 95% total line coverage for the default deterministic suite.
+- `make examples-test` executes the checked-in runnable examples.
+- `make examples-coverage` requires every curated top-level `__all__` export to appear in at least one runnable example.
+
 Optional but useful:
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,14 @@ SPHINX ?= $(PYTHON) -m sphinx
 BUILD ?= $(PYTHON) -m build
 TWINE ?= $(PYTHON) -m twine
 TRUSSME_SPEC ?= trussme>=0.1.0
-COVERAGE_MIN ?= 90
+COVERAGE_MIN ?= 95
 COVERAGE_MINIMUM ?= $(COVERAGE_MIN)
 FULL_EXTRAS ?= dev,battery,grammar,mcp,cad,pandas,solvers
 
 .PHONY: help check-python dev install-dev \
 	lint fmt fmt-check type test qa coverage release-check \
 	docstrings-check \
-	examples-smoke examples-test examples-metrics \
+	examples-smoke examples-test examples-coverage examples-metrics \
 	docs docs-build docs-check docs-linkcheck \
 	install-trussme install-pybamm dev-truss dev-battery dev-full \
 	test-trussme test-full \
@@ -31,6 +31,7 @@ help:
 	@echo "  test                 Run the default pytest suite."
 	@echo "  test-trussme         Run tests that require an installed trussme package."
 	@echo "  test-full            Run full pytest suite and examples smoke checks."
+	@echo "  examples-coverage    Require every public API export to appear in an example."
 	@echo "  release-check        Build sdist/wheel and run twine metadata checks."
 	@echo "  docstrings-check     Enforce Google-style docstring policy."
 	@echo "  ci                   Run the main local CI checks."
@@ -84,6 +85,9 @@ examples-metrics: check-python examples-test
 	$(PYTHON) scripts/generate_examples_metrics.py
 	$(PYTHON) scripts/generate_examples_badges.py
 
+examples-coverage: examples-metrics
+	$(PYTHON) scripts/check_example_api_coverage.py --minimum 100
+
 docs-build: check-python
 	$(PYTHON) scripts/generate_example_docs.py
 	$(PYTHON) scripts/generate_problem_catalog_docs.py
@@ -120,7 +124,7 @@ test-full: check-python
 	PYTHONPATH=src $(PYTEST) -q -rs
 	PYTHONPATH=src $(PYTEST) -m examples_smoke -q
 
-ci: qa coverage docstrings-check docs-check examples-smoke release-check
+ci: qa coverage docstrings-check docs-check examples-smoke examples-coverage release-check
 
 clean:
 	rm -rf .coverage .mypy_cache .pytest_cache .ruff_cache artifacts build dist docs/_build src/design_research_problems.egg-info

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![CI](https://github.com/cmudrc/design-research-problems/actions/workflows/ci.yml/badge.svg)](https://github.com/cmudrc/design-research-problems/actions/workflows/ci.yml)
 [![Coverage](https://raw.githubusercontent.com/cmudrc/design-research-problems/HEAD/.github/badges/coverage.svg)](https://github.com/cmudrc/design-research-problems/actions/workflows/ci.yml)
 [![Examples Passing](https://raw.githubusercontent.com/cmudrc/design-research-problems/HEAD/.github/badges/examples-passing.svg)](https://github.com/cmudrc/design-research-problems/actions/workflows/examples.yml)
-[![Public API In Examples](https://raw.githubusercontent.com/cmudrc/design-research-problems/HEAD/.github/badges/examples-api-coverage.svg)](https://github.com/cmudrc/design-research-problems/actions/workflows/examples.yml)
+[![API in Examples](https://raw.githubusercontent.com/cmudrc/design-research-problems/HEAD/.github/badges/examples-api-coverage.svg)](https://github.com/cmudrc/design-research-problems/actions/workflows/examples.yml)
 [![Docs](https://github.com/cmudrc/design-research-problems/actions/workflows/docs-pages.yml/badge.svg)](https://github.com/cmudrc/design-research-problems/actions/workflows/docs-pages.yml)
 [![PyPI Version](https://img.shields.io/pypi/v/design-research-problems.svg)](https://pypi.org/project/design-research-problems/)
 [![Python Versions](https://img.shields.io/pypi/pyversions/design-research-problems.svg)](https://pypi.org/project/design-research-problems/)
@@ -10,6 +10,14 @@
 `design-research-problems` is a compact library and compendium of design research
 problems. It packages canonical research prompts, optimization benchmarks, and
 discrete grammar-style problems behind a small, typed Python API.
+
+## Quality Signals
+
+- **Coverage** reports total line coverage for the default deterministic test suite; CI requires at least 95%.
+- **Examples Passing** reports checked-in example scripts that execute successfully in the examples workflow.
+- **API in Examples** reports curated top-level `__all__` exports referenced by runnable examples. `N/N` means every supported top-level export appears in at least one example, and CI requires 100%.
+
+Run `make coverage`, `make examples-test`, and `make examples-coverage` to reproduce these checks locally.
 
 ## Overview
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -20,6 +20,7 @@ The top-level package exports a small curated public API:
 - ``OptimizationProblem``
 - ``Problem``
 - ``ProblemAsset``
+- ``ProblemCatalogSummary``
 - ``ProblemEvaluationError``
 - ``ProblemKind``
 - ``ProblemMetadata``
@@ -29,5 +30,6 @@ The top-level package exports a small curated public API:
 - ``get_ideation_catalog``
 - ``get_problem``
 - ``list_problems``
+- ``search_problem_summaries``
 
 See :doc:`reference/index` for the module-level reference pages.

--- a/docs/dependencies_and_extras.rst
+++ b/docs/dependencies_and_extras.rst
@@ -65,6 +65,8 @@ Recommended install profiles:
 - structural grammar studies: ``pip install -e ".[grammar]"``
 - battery studies: ``pip install -e ".[battery]"``
 - external-tool workflows: ``pip install -e ".[mcp,cad]"``
+- DRAG/DERP agent workflows:
+  ``pip install "design-research-agents[mcp,gemini]" "design-research-problems[mcp]"``
 - broad optional-toolkit install: ``pip install -e ".[all]"``
 - full local validation environment: ``make dev-full``
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,7 +30,7 @@ and downstream analyses.
           <img alt="Examples Passing" src="https://raw.githubusercontent.com/cmudrc/design-research-problems/HEAD/.github/badges/examples-passing.svg">
         </a>
         <a class="drc-badge-link" href="https://github.com/cmudrc/design-research-problems/actions/workflows/examples.yml">
-          <img alt="Public API In Examples" src="https://raw.githubusercontent.com/cmudrc/design-research-problems/HEAD/.github/badges/examples-api-coverage.svg">
+          <img alt="API in Examples" src="https://raw.githubusercontent.com/cmudrc/design-research-problems/HEAD/.github/badges/examples-api-coverage.svg">
         </a>
         <a class="drc-badge-link" href="https://github.com/cmudrc/design-research-problems/actions/workflows/docs-pages.yml">
           <img alt="Docs" src="https://github.com/cmudrc/design-research-problems/actions/workflows/docs-pages.yml/badge.svg">
@@ -42,6 +42,20 @@ and downstream analyses.
           <img alt="Python Versions" src="https://img.shields.io/pypi/pyversions/design-research-problems.svg">
         </a>
       </div>
+
+Quality Signals
+---------------
+
+- ``Coverage`` reports total line coverage for the default deterministic test
+  suite; CI requires at least 95%.
+- ``Examples Passing`` reports checked-in example scripts that execute
+  successfully in the examples workflow.
+- ``API in Examples`` reports curated top-level ``__all__`` exports referenced
+  by runnable examples. ``N/N`` means every supported top-level export appears
+  in at least one example, and CI requires 100%.
+
+Run ``make coverage``, ``make examples-test``, and ``make examples-coverage``
+to reproduce these checks locally.
 
 Highlights
 ----------

--- a/docs/problems/optimization.rst
+++ b/docs/problems/optimization.rst
@@ -3,6 +3,11 @@ Optimization Problems
 
 Optimization problems expose typed bounds, solver-independent constraints, and
 problem-specific representative baseline `solve()` implementations.
+They also expose `solver_hints()` for agent-facing solver selection. The hint
+payload includes variable domain, numeric bounds, constraint counts, objective
+mode, and a compact solver-family recommendation, and the same payload is
+available through the `solver_hints` tool when an optimization problem is served
+over MCP.
 
 The smooth continuous packaged benchmarks in this family continue to use SciPy
 baselines.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -30,8 +30,15 @@ Or install from source:
    import design_research_problems as derp
 
    print(f"Catalog size: {len(derp.list_problems())}")
+   summaries = derp.search_problem_summaries(text="pill", kind="optimization")
+   print(summaries[0].to_dict())
+
    problem = derp.get_problem("ideation_peanut_shelling_fu_cagan_kotovsky_2010")
    print(problem.render_brief(include_citation=False))
+
+   optimization = derp.get_problem("pill_capsule_min_area")
+   if isinstance(optimization, derp.OptimizationProblem):
+       print(optimization.solver_hints())
 
 3. What Happened
 ----------------
@@ -39,6 +46,11 @@ Or install from source:
 You loaded one packaged study task from the catalog and rendered its design
 brief. This is the core pattern for building comparable task inputs before
 adding evaluators, solvers, or orchestration.
+
+``search_problem_summaries`` returns compact metadata for selection and routing
+without putting every full problem brief into an agent context window.
+Optimization problems also expose ``solver_hints()`` so callers can see bounds,
+variable domain, constraint counts, and a solver-family hint directly.
 
 4. Where To Go Next
 -------------------

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -1,10 +1,12 @@
 Reference
 =========
 
+The cross-library handoff schema is documented in
+:doc:`../downstream_metadata_contract`.
+
 .. toctree::
    :maxdepth: 1
 
-   ../downstream_metadata_contract
    problems
    registry
    shared

--- a/examples/catalog/public_api_tour.py
+++ b/examples/catalog/public_api_tour.py
@@ -11,6 +11,8 @@ def main() -> None:
     """Load one example from each family and print typed public-API touchpoints."""
     registry = derp.ProblemRegistry()
     catalog: derp.IdeationCatalog = derp.get_ideation_catalog()
+    summaries: tuple[derp.ProblemCatalogSummary, ...] = derp.search_problem_summaries(text="battery")[:2]
+    integration_module = derp.integration
 
     text_problem = derp.get_problem("ideation_peanut_shelling_fu_cagan_kotovsky_2010")
     typed_text_problem = derp.get_problem_as(
@@ -73,6 +75,9 @@ def main() -> None:
     handled_optional_error = derp.MissingOptionalDependencyError.__name__
 
     print("problem-count", len(derp.list_problems()))
+    print("package-version", derp.__version__)
+    print("search-results", [summary.problem_id for summary in summaries])
+    print("integration-module", integration_module.__name__)
     print("kind-count", len(kinds), sorted(kind.value for kind in kinds))
     print("loaded-types", [type(problem).__name__ for problem in loaded_problems])
     print("computable-count", computable_count)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ where = ["src"]
 [tool.setuptools.package-data]
 design_research_problems = [
   "py.typed",
+  "*.pyi",
   "_assets/catalog/*/*.toml",
   "_assets/catalog/*/*.bib",
   "_assets/catalog/*/*/*.toml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "design-research-problems"
-version = "0.3.0"
+version = "0.4.0"
 description = "A compendium of canonical design research problems"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/check_example_api_coverage.py
+++ b/scripts/check_example_api_coverage.py
@@ -1,0 +1,34 @@
+"""Enforce complete public-API representation in runnable examples."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+DEFAULT_METRICS = Path("artifacts/examples/examples_metrics.json")
+
+
+def main() -> int:
+    """Read generated metrics and enforce the configured API-in-examples floor."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--metrics", type=Path, default=DEFAULT_METRICS)
+    parser.add_argument("--minimum", type=float, default=100.0)
+    args = parser.parse_args()
+
+    metrics = json.loads(args.metrics.read_text(encoding="utf-8"))
+    public_api = metrics["public_api"]
+    covered = int(public_api["covered_exports"])
+    total = int(public_api["total_exports"])
+    percentage = float(public_api["coverage_percent"])
+
+    print(f"API in examples: {percentage:.1f}% ({covered}/{total})")
+    if percentage < args.minimum:
+        print(f"Coverage threshold failed: {percentage:.1f}% < {args.minimum:.1f}%")
+        return 1
+    print("API-in-examples threshold passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_examples_badges.py
+++ b/scripts/generate_examples_badges.py
@@ -61,7 +61,7 @@ def _render_badge(label: str, message: str, color: str) -> str:
     total_width = label_width + message_width
     label_x = label_width / 2
     message_x = label_width + (message_width / 2)
-    return f"""<svg xmlns="http://www.w3.org/2000/svg" width="{total_width}" 
+    return f"""<svg xmlns="http://www.w3.org/2000/svg" width="{total_width}"
     height="20" role="img" aria-label="{label}: {message}">
   <linearGradient id="g" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
@@ -122,7 +122,7 @@ def main() -> None:
     api_coverage_percent = round((covered_exports / total_exports) * 100.0) if total_exports else 100
     API_BADGE.write_text(
         _render_badge(
-            "Example API Coverage",
+            "API in Examples",
             f"{covered_exports}/{total_exports}",
             _pick_color(api_coverage_percent),
         ),

--- a/scripts/generate_examples_metrics.py
+++ b/scripts/generate_examples_metrics.py
@@ -16,7 +16,7 @@ def main() -> None:
 
     example_files = sorted(ROOT.glob("examples/**/*.py"))
     combined_source = "\n".join(path.read_text(encoding="utf-8") for path in example_files)
-    public_api = {name for name in drp.__all__ if name != "__version__"}
+    public_api = set(drp.__all__)
     used = sorted(name for name in public_api if name in combined_source)
     example_count = len(example_files)
     covered_exports = len(used)

--- a/src/design_research_problems/__init__.py
+++ b/src/design_research_problems/__init__.py
@@ -13,6 +13,7 @@ _EXPORTS: Final[dict[str, str]] = {
     "ComputableProblem": "design_research_problems.problems:ComputableProblem",
     "ProblemKind": "design_research_problems.problems:ProblemKind",
     "ProblemMetadata": "design_research_problems.problems:ProblemMetadata",
+    "ProblemCatalogSummary": "design_research_problems.problems:ProblemCatalogSummary",
     "ProblemTaxonomy": "design_research_problems.problems:ProblemTaxonomy",
     "Citation": "design_research_problems.problems:Citation",
     "ProblemAsset": "design_research_problems.problems:ProblemAsset",
@@ -36,6 +37,7 @@ _EXPORTS: Final[dict[str, str]] = {
     "get_problem": "design_research_problems._catalog:get_problem",
     "get_problem_as": "design_research_problems._catalog:get_problem_as",
     "list_problems": "design_research_problems._catalog:list_problems",
+    "search_problem_summaries": "design_research_problems._catalog:search_problem_summaries",
     "get_ideation_catalog": "design_research_problems.ideation:get_ideation_catalog",
 }
 
@@ -84,6 +86,7 @@ if TYPE_CHECKING:
     from ._catalog import get_problem as get_problem
     from ._catalog import get_problem_as as get_problem_as
     from ._catalog import list_problems as list_problems
+    from ._catalog import search_problem_summaries as search_problem_summaries
     from ._exceptions import MissingOptionalDependencyError as MissingOptionalDependencyError
     from ._exceptions import ProblemEvaluationError as ProblemEvaluationError
     from .ideation import EvidenceTier as EvidenceTier
@@ -106,6 +109,7 @@ if TYPE_CHECKING:
     from .problems import OptimizationProblem as OptimizationProblem
     from .problems import Problem as Problem
     from .problems import ProblemAsset as ProblemAsset
+    from .problems import ProblemCatalogSummary as ProblemCatalogSummary
     from .problems import ProblemKind as ProblemKind
     from .problems import ProblemMetadata as ProblemMetadata
     from .problems import ProblemTaxonomy as ProblemTaxonomy

--- a/src/design_research_problems/__init__.py
+++ b/src/design_research_problems/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from importlib import import_module
 from importlib.metadata import PackageNotFoundError, version
-from typing import TYPE_CHECKING, Final
+from typing import Final
 
 from design_research_problems._lazy_exports import module_dir, resolve_lazy_export
 
@@ -79,38 +79,3 @@ def __dir__() -> list[str]:
         Sorted attribute list for interactive discovery.
     """
     return module_dir(globals(), __all__)
-
-
-if TYPE_CHECKING:
-    from ._catalog import ProblemRegistry as ProblemRegistry
-    from ._catalog import get_problem as get_problem
-    from ._catalog import get_problem_as as get_problem_as
-    from ._catalog import list_problems as list_problems
-    from ._catalog import search_problem_summaries as search_problem_summaries
-    from ._exceptions import MissingOptionalDependencyError as MissingOptionalDependencyError
-    from ._exceptions import ProblemEvaluationError as ProblemEvaluationError
-    from .ideation import EvidenceTier as EvidenceTier
-    from .ideation import IdeationCatalog as IdeationCatalog
-    from .ideation import IdeationPromptFamily as IdeationPromptFamily
-    from .ideation import IdeationPromptRecord as IdeationPromptRecord
-    from .ideation import IdeationPromptVariant as IdeationPromptVariant
-    from .ideation import IdeationStudy as IdeationStudy
-    from .ideation import get_ideation_catalog as get_ideation_catalog
-    from .integration import evaluate_problem_output as evaluate_problem_output
-    from .integration import resolve_problem_binding as resolve_problem_binding
-    from .problems import Citation as Citation
-    from .problems import ComputableProblem as ComputableProblem
-    from .problems import DecisionEvaluation as DecisionEvaluation
-    from .problems import DecisionProblem as DecisionProblem
-    from .problems import GrammarProblem as GrammarProblem
-    from .problems import GrammarTransition as GrammarTransition
-    from .problems import MCPProblem as MCPProblem
-    from .problems import OptimizationEvaluation as OptimizationEvaluation
-    from .problems import OptimizationProblem as OptimizationProblem
-    from .problems import Problem as Problem
-    from .problems import ProblemAsset as ProblemAsset
-    from .problems import ProblemCatalogSummary as ProblemCatalogSummary
-    from .problems import ProblemKind as ProblemKind
-    from .problems import ProblemMetadata as ProblemMetadata
-    from .problems import ProblemTaxonomy as ProblemTaxonomy
-    from .problems import TextProblem as TextProblem

--- a/src/design_research_problems/__init__.pyi
+++ b/src/design_research_problems/__init__.pyi
@@ -1,0 +1,35 @@
+"""Static public interface for the lazy package exports."""
+
+from . import integration as integration
+from ._catalog import ProblemRegistry as ProblemRegistry
+from ._catalog import get_problem as get_problem
+from ._catalog import get_problem_as as get_problem_as
+from ._catalog import list_problems as list_problems
+from ._catalog import search_problem_summaries as search_problem_summaries
+from ._exceptions import MissingOptionalDependencyError as MissingOptionalDependencyError
+from ._exceptions import ProblemEvaluationError as ProblemEvaluationError
+from .ideation import EvidenceTier as EvidenceTier
+from .ideation import IdeationCatalog as IdeationCatalog
+from .ideation import IdeationPromptFamily as IdeationPromptFamily
+from .ideation import IdeationPromptRecord as IdeationPromptRecord
+from .ideation import IdeationPromptVariant as IdeationPromptVariant
+from .ideation import IdeationStudy as IdeationStudy
+from .ideation import get_ideation_catalog as get_ideation_catalog
+from .problems import Citation as Citation
+from .problems import ComputableProblem as ComputableProblem
+from .problems import DecisionEvaluation as DecisionEvaluation
+from .problems import DecisionProblem as DecisionProblem
+from .problems import GrammarProblem as GrammarProblem
+from .problems import GrammarTransition as GrammarTransition
+from .problems import MCPProblem as MCPProblem
+from .problems import OptimizationEvaluation as OptimizationEvaluation
+from .problems import OptimizationProblem as OptimizationProblem
+from .problems import Problem as Problem
+from .problems import ProblemAsset as ProblemAsset
+from .problems import ProblemCatalogSummary as ProblemCatalogSummary
+from .problems import ProblemKind as ProblemKind
+from .problems import ProblemMetadata as ProblemMetadata
+from .problems import ProblemTaxonomy as ProblemTaxonomy
+from .problems import TextProblem as TextProblem
+
+__version__: str

--- a/src/design_research_problems/_catalog/__init__.py
+++ b/src/design_research_problems/_catalog/__init__.py
@@ -1,5 +1,5 @@
 """Catalog loading and registry exports."""
 
-from ._registry import ProblemRegistry, get_problem, get_problem_as, list_problems
+from ._registry import ProblemRegistry, get_problem, get_problem_as, list_problems, search_problem_summaries
 
-__all__ = ["ProblemRegistry", "get_problem", "get_problem_as", "list_problems"]
+__all__ = ["ProblemRegistry", "get_problem", "get_problem_as", "list_problems", "search_problem_summaries"]

--- a/src/design_research_problems/_catalog/_registry.py
+++ b/src/design_research_problems/_catalog/_registry.py
@@ -11,7 +11,7 @@ from design_research_problems._catalog._manifest import ProblemManifest
 from design_research_problems._exceptions import ProblemEvaluationError
 from design_research_problems.problems import MCPProblem, Problem, ProblemKind, TextProblem
 from design_research_problems.problems._decision import load_decision_problem
-from design_research_problems.problems._metadata import ProblemMetadata
+from design_research_problems.problems._metadata import ProblemCatalogSummary, ProblemMetadata
 
 if TYPE_CHECKING:
     from design_research_problems.problems import (
@@ -287,6 +287,40 @@ class ProblemRegistry:
             matches.append(metadata)
         return tuple(matches)
 
+    def summaries(
+        self,
+        tags: tuple[str, ...] = (),
+        text: str = "",
+        feature_flags: tuple[str, ...] = (),
+        kind: ProblemKind | None = None,
+        capabilities: tuple[str, ...] = (),
+        study_suitability: tuple[str, ...] = (),
+    ) -> tuple[ProblemCatalogSummary, ...]:
+        """Return compact search results for agent-facing problem selection.
+
+        Args:
+            tags: Tags that must all be present on a matching entry.
+            text: Case-insensitive free-text search term.
+            feature_flags: Feature flags that must all be present on a matching entry.
+            kind: Optional problem-family filter.
+            capabilities: Capability flags that must all be present.
+            study_suitability: Study-suitability flags that must all be present.
+
+        Returns:
+            Compact summaries for matching entries in deterministic order.
+        """
+        return tuple(
+            ProblemCatalogSummary.from_metadata(metadata)
+            for metadata in self.search(
+                tags=tags,
+                text=text,
+                feature_flags=feature_flags,
+                kind=kind,
+                capabilities=capabilities,
+                study_suitability=study_suitability,
+            )
+        )
+
     @overload
     def get(
         self, problem_id: Literal["battery_18650_t1_rectangular_surrogate_grammar"]
@@ -489,6 +523,20 @@ class ProblemRegistry:
 _DEFAULT_REGISTRY = ProblemRegistry()
 
 
+def _coerce_problem_kind(kind: ProblemKind | str | None) -> ProblemKind | None:
+    """Normalize an optional problem-kind filter.
+
+    Args:
+        kind: ProblemKind value, string value, or ``None``.
+
+    Returns:
+        Normalized kind or ``None``.
+    """
+    if kind is None or isinstance(kind, ProblemKind):
+        return kind
+    return ProblemKind(kind.strip().lower())
+
+
 def list_problems() -> tuple[str, ...]:
     """Return all packaged problem IDs.
 
@@ -496,6 +544,46 @@ def list_problems() -> tuple[str, ...]:
         Stable problem IDs in sorted order.
     """
     return tuple(metadata.problem_id for metadata in _DEFAULT_REGISTRY.list())
+
+
+def search_problem_summaries(
+    *,
+    tags: tuple[str, ...] = (),
+    text: str = "",
+    feature_flags: tuple[str, ...] = (),
+    kind: ProblemKind | str | None = None,
+    capabilities: tuple[str, ...] = (),
+    study_suitability: tuple[str, ...] = (),
+) -> tuple[ProblemCatalogSummary, ...]:
+    """Search the packaged catalog and return compact problem summaries.
+
+    This is the agent-facing counterpart to loading full briefs with
+    ``get_problem(...).render_brief()``. It keeps context windows small while
+    still exposing problem IDs, titles, kinds, taxonomy, tags, and capability
+    flags needed for routing.
+
+    Args:
+        tags: Tags that must all be present on a matching entry.
+        text: Case-insensitive free-text search term.
+        feature_flags: Feature flags that must all be present on a matching entry.
+        kind: Optional problem-family filter as a ``ProblemKind`` or string value.
+        capabilities: Capability flags that must all be present.
+        study_suitability: Study-suitability flags that must all be present.
+
+    Returns:
+        Compact summaries for matching entries in deterministic order.
+
+    Raises:
+        ValueError: If ``kind`` is a string that is not a known problem kind.
+    """
+    return _DEFAULT_REGISTRY.summaries(
+        tags=tags,
+        text=text,
+        feature_flags=feature_flags,
+        kind=_coerce_problem_kind(kind),
+        capabilities=capabilities,
+        study_suitability=study_suitability,
+    )
 
 
 @overload

--- a/src/design_research_problems/problems/__init__.py
+++ b/src/design_research_problems/problems/__init__.py
@@ -14,7 +14,15 @@ from ._decision import (
 )
 from ._grammar import GrammarProblem, GrammarTransition
 from ._mcp_problem import MCPProblem
-from ._metadata import Citation, ProblemAsset, ProblemBenchmarkCard, ProblemKind, ProblemMetadata, ProblemTaxonomy
+from ._metadata import (
+    Citation,
+    ProblemAsset,
+    ProblemBenchmarkCard,
+    ProblemCatalogSummary,
+    ProblemKind,
+    ProblemMetadata,
+    ProblemTaxonomy,
+)
 from ._optimization import OptimizationEvaluation, OptimizationProblem
 from ._problem import Problem
 from ._text import TextProblem
@@ -39,6 +47,7 @@ __all__ = [
     "Problem",
     "ProblemAsset",
     "ProblemBenchmarkCard",
+    "ProblemCatalogSummary",
     "ProblemKind",
     "ProblemMetadata",
     "ProblemTaxonomy",

--- a/src/design_research_problems/problems/_battery_tier_problems.py
+++ b/src/design_research_problems/problems/_battery_tier_problems.py
@@ -210,67 +210,13 @@ class Battery18650Tier1SeriesParallelOptimizationProblem(BatteryGridSizingProble
             float(self.requirements.minimum_current_a) if load_current_a is None else float(load_current_a)
         )
 
-    @classmethod
-    def from_manifest(cls, manifest: ProblemManifest) -> Battery18650Tier1SeriesParallelOptimizationProblem:
-        """Construct one tier-1 optimizer from manifest data."""
-        parameters = manifest.parameters
-        return cls(
-            metadata=manifest.metadata,
-            statement_markdown=manifest.statement_markdown,
-            resource_bundle=cls.resource_bundle_from_manifest(manifest),
-            requirements=parse_battery_requirements(manifest),
-            backend_config=parse_battery_backend_config(manifest),
-            objective_weights=BatteryObjectiveWeights.from_mapping(
-                parameters.get("objective_weights"),
-                default_volume=0.20,
-                default_cost=0.65,
-                default_temperature=0.15,
-            ),
-            cooling_coefficient_w_per_m2k=float(
-                cast(float, parameters.get("cooling_coefficient_w_per_m2k", _DEFAULT_COOLING_COEFFICIENT))
-            ),
-            passive_cooling_w_per_k=float(
-                cast(float, parameters.get("passive_cooling_w_per_k", _DEFAULT_PASSIVE_COOLING))
-            ),
-            ambient_temperature_c=float(
-                cast(float, parameters.get("ambient_temperature_c", _DEFAULT_AMBIENT_TEMPERATURE_C))
-            ),
-            maximum_temperature_c=float(
-                cast(float, parameters.get("maximum_temperature_c", _DEFAULT_MAX_TEMPERATURE_C))
-            ),
-            load_current_a=cast(float | None, parameters.get("load_current_a")),
-        )
-
     def _connection_count(self, series_count: int, parallel_count: int) -> int:
         """Return canonical connection count for rectangular ``SxP`` bus wiring."""
         return max(0, series_count + 1) * max(0, parallel_count - 1)
 
     def _metrics_from_variables(self, variables: NDArray[numpy.float64]) -> BatteryTierMetrics:
-        """Return tier-1 metrics for one candidate vector."""
-        evaluation = self._evaluation_from_variables(variables)
-        state = self.decode_candidate(variables)
-        peak_temperature = _thermal_peak_temperature_c(
-            cell_count=evaluation.cell_count,
-            parallel_equivalent=float(state.parallel_count),
-            surface_area_mm2=evaluation.surface_area,
-            load_current_a=self.load_current_a,
-            cooling_coefficient_w_per_m2k=self.cooling_coefficient_w_per_m2k,
-            passive_cooling_w_per_k=self.passive_cooling_w_per_k,
-            ambient_temperature_c=self.ambient_temperature_c,
-        )
-        return BatteryTierMetrics(
-            cell_count=float(evaluation.cell_count),
-            connection_count=float(self._connection_count(state.series_count, state.parallel_count)),
-            cost_usd=float(evaluation.design_cost),
-            design_volume_mm3=float(evaluation.design_volume),
-            max_temperature_c=peak_temperature,
-            voltage_v=float(evaluation.design_voltage),
-            capacity_ah=float(evaluation.design_capacity),
-            current_limit_a=float(evaluation.analytic_current_limit),
-            min_clearance_mm=float(MIN_SPACING_MM),
-            is_feasible=bool(evaluation.is_feasible),
-            failure_reason=evaluation.failure_reason,
-        )
+        """Return tier-specific metrics implemented by concrete Tier 1 variants."""
+        raise NotImplementedError
 
     def objective_components(self, variables: NDArray[numpy.float64]) -> dict[str, float]:
         """Return the shared battery metric contract for one candidate."""
@@ -718,38 +664,6 @@ class Battery18650Tier3TopologyOptimizationProblem(_TierOrientedOptimizationBase
             ConstraintDefinition(kind="ineq", evaluate=self._stage_completeness_margin),
         ]
 
-    @classmethod
-    def from_manifest(cls, manifest: ProblemManifest) -> Battery18650Tier3TopologyOptimizationProblem:
-        """Construct one tier-3 optimizer from manifest data."""
-        parameters = manifest.parameters
-        return cls(
-            metadata=manifest.metadata,
-            statement_markdown=manifest.statement_markdown,
-            resource_bundle=cls.resource_bundle_from_manifest(manifest),
-            requirements=parse_battery_requirements(manifest),
-            max_cell_count=int(cast(int, parameters.get("max_cell_count", 24))),
-            minimum_spacing_mm=float(cast(float, parameters.get("minimum_spacing_mm", MIN_SPACING_MM))),
-            objective_weights=BatteryObjectiveWeights.from_mapping(
-                parameters.get("objective_weights"),
-                default_volume=0.40,
-                default_cost=0.30,
-                default_temperature=0.30,
-            ),
-            cooling_coefficient_w_per_m2k=float(
-                cast(float, parameters.get("cooling_coefficient_w_per_m2k", _DEFAULT_COOLING_COEFFICIENT))
-            ),
-            passive_cooling_w_per_k=float(
-                cast(float, parameters.get("passive_cooling_w_per_k", _DEFAULT_PASSIVE_COOLING))
-            ),
-            ambient_temperature_c=float(
-                cast(float, parameters.get("ambient_temperature_c", _DEFAULT_AMBIENT_TEMPERATURE_C))
-            ),
-            maximum_temperature_c=float(
-                cast(float, parameters.get("maximum_temperature_c", _DEFAULT_MAX_TEMPERATURE_C))
-            ),
-            load_current_a=cast(float | None, parameters.get("load_current_a")),
-        )
-
     def generate_initial_solution(self, seed: int | None = None) -> NDArray[numpy.float64]:
         """Return deterministic or seeded tier-3 initial candidate."""
         baseline_series = max(1, round(self.requirements.target_voltage_v / CELL_SPEC_18650.nominal_voltage_v))
@@ -805,44 +719,6 @@ class Battery18650Tier3TopologyOptimizationProblem(_TierOrientedOptimizationBase
             target = 6 * index
             pose_values[target : target + 6] = normalized[source : source + 6]
         return (decoded.cell_count, pose_values)
-
-    def _metrics_from_variables(self, variables: NDArray[numpy.float64]) -> BatteryTierMetrics:
-        normalized = self._normalize_vector(variables)
-        decoded = self._decode(normalized)
-        active_count, pose_values = self._active_count_and_pose_variables(normalized)
-        helper = self._pose_helper_evaluation(active_cell_count=active_count, pose_variables=pose_values)
-        min_stage_population = min(decoded.stage_counts, default=0)
-        voltage_v = float(decoded.series_count) * CELL_SPEC_18650.nominal_voltage_v
-        capacity_ah = float(min_stage_population) * CELL_SPEC_18650.nominal_capacity_ah
-        current_limit_a = (
-            float(min_stage_population) * CELL_SPEC_18650.nominal_capacity_ah * CELL_SPEC_18650.max_discharge_rate_c
-        )
-        connection_count = float(
-            sum(max(0, count - 1) for count in decoded.stage_counts) + max(0, decoded.series_count - 1)
-        )
-        max_temperature_c = _thermal_peak_temperature_c(
-            cell_count=decoded.cell_count,
-            parallel_equivalent=float(max(min_stage_population, 1)),
-            surface_area_mm2=float(helper.surface_area_mm2),
-            load_current_a=self.load_current_a,
-            cooling_coefficient_w_per_m2k=self.cooling_coefficient_w_per_m2k,
-            passive_cooling_w_per_k=self.passive_cooling_w_per_k,
-            ambient_temperature_c=self.ambient_temperature_c,
-        )
-        failure_reason = None if min_stage_population > 0 else "At least one series stage is empty."
-        return BatteryTierMetrics(
-            cell_count=float(decoded.cell_count),
-            connection_count=connection_count,
-            cost_usd=float(decoded.cell_count) * CELL_SPEC_18650.unit_cost_usd,
-            design_volume_mm3=float(helper.design_volume_mm3),
-            max_temperature_c=max_temperature_c,
-            voltage_v=voltage_v,
-            capacity_ah=capacity_ah,
-            current_limit_a=current_limit_a,
-            min_clearance_mm=float(helper.minimum_surface_clearance_mm),
-            is_feasible=failure_reason is None,
-            failure_reason=failure_reason,
-        )
 
     def _stage_completeness_margin(self, variables: NDArray[numpy.float64]) -> float:
         return float(min(self._decode(variables).stage_counts, default=0))
@@ -964,57 +840,6 @@ class Battery18650Tier4ThermalOptimizationProblem(Battery18650Tier3TopologyOptim
     def _thermal_priors(self, value: BatteryThermalPriors | None) -> None:
         """Override the cached thermal priors, primarily for tests."""
         self._thermal_priors_cache = value
-
-    @classmethod
-    def from_manifest(cls, manifest: ProblemManifest) -> Battery18650Tier4ThermalOptimizationProblem:
-        """Construct one tier-4 optimizer from manifest data."""
-        parameters = manifest.parameters
-        cooling_bounds = cast(
-            dict[str, float], parameters.get("cooling_coefficient_bounds", {"lower": 5.0, "upper": 50.0})
-        )
-        passive_bounds = cast(dict[str, float], parameters.get("passive_cooling_bounds", {"lower": 0.1, "upper": 10.0}))
-        ambient_bounds = cast(
-            dict[str, float], parameters.get("ambient_temperature_bounds", {"lower": 5.0, "upper": 45.0})
-        )
-        return cls(
-            metadata=manifest.metadata,
-            statement_markdown=manifest.statement_markdown,
-            resource_bundle=cls.resource_bundle_from_manifest(manifest),
-            requirements=parse_battery_requirements(manifest),
-            max_cell_count=int(cast(int, parameters.get("max_cell_count", 24))),
-            minimum_spacing_mm=float(cast(float, parameters.get("minimum_spacing_mm", MIN_SPACING_MM))),
-            objective_weights=BatteryObjectiveWeights.from_mapping(
-                parameters.get("objective_weights"),
-                default_volume=0.35,
-                default_cost=0.25,
-                default_temperature=0.40,
-            ),
-            cooling_coefficient_bounds=(
-                float(cooling_bounds.get("lower", 5.0)),
-                float(cooling_bounds.get("upper", 50.0)),
-            ),
-            passive_cooling_bounds=(
-                float(passive_bounds.get("lower", 0.1)),
-                float(passive_bounds.get("upper", 10.0)),
-            ),
-            ambient_temperature_bounds=(
-                float(ambient_bounds.get("lower", 5.0)),
-                float(ambient_bounds.get("upper", 45.0)),
-            ),
-            thermal_model=str(cast(str, parameters.get("thermal_model", _DEFAULT_THERMAL_MODEL))),
-            thermal_neighbor_clearance_mm=float(cast(float, parameters.get("thermal_neighbor_clearance_mm", 8.0))),
-            thermal_contact_decay_mm=float(cast(float, parameters.get("thermal_contact_decay_mm", 2.0))),
-            thermal_contact_resistance_k_per_w=float(
-                cast(float, parameters.get("thermal_contact_resistance_k_per_w", 2.5))
-            ),
-            thermal_flow_shadowing_factor=float(cast(float, parameters.get("thermal_flow_shadowing_factor", 0.25))),
-            thermal_airflow_axis=str(cast(str, parameters.get("thermal_airflow_axis", "x"))),
-            thermal_reference_soc=float(cast(float, parameters.get("thermal_reference_soc", 0.5))),
-            maximum_temperature_c=float(
-                cast(float, parameters.get("maximum_temperature_c", _DEFAULT_MAX_TEMPERATURE_C))
-            ),
-            load_current_a=cast(float | None, parameters.get("load_current_a")),
-        )
 
     def generate_initial_solution(self, seed: int | None = None) -> NDArray[numpy.float64]:
         """Return deterministic or seeded tier-4 initial candidate."""
@@ -1327,44 +1152,6 @@ class Battery18650Tier4ThermalOptimizationProblem(Battery18650Tier3TopologyOptim
             "coolant_temperature_c": diagnostics.coolant_temperature_c,
             "max_core_surface_delta_c": diagnostics.max_core_surface_delta_c,
         }
-
-    def _metrics_from_variables(self, variables: NDArray[numpy.float64]) -> BatteryTierMetrics:
-        normalized = self._normalize_vector(variables)
-        if normalized.shape[0] != self.bounds.lb.shape[0]:
-            raise ValueError("Tier-4 metric evaluation requires the full tier-4 design vector.")
-        base_vector = normalized[:-3]
-        base_metrics = super()._metrics_from_variables(base_vector)
-        cooling_coefficient, passive_cooling, ambient_temperature = self._thermal_parameters_from_variables(normalized)
-        active_count, pose_values = super()._active_count_and_pose_variables(base_vector)
-        pose_eval = self._pose_helper_evaluation(active_cell_count=active_count, pose_variables=pose_values)
-        decoded = super()._decode(base_vector)
-        thermal_solution = self._solve_thermal_network(
-            decoded=decoded,
-            pose_evaluation=pose_eval,
-            cooling_coefficient_w_per_m2k=cooling_coefficient,
-            passive_cooling_w_per_k=passive_cooling,
-            ambient_temperature_c=ambient_temperature,
-        )
-        self._latest_thermal_diagnostics = Tier4ThermalDiagnostics(
-            thermal_model=self.thermal_model,
-            max_core_temperature_c=thermal_solution.max_core_temperature_c,
-            max_surface_temperature_c=thermal_solution.max_surface_temperature_c,
-            coolant_temperature_c=thermal_solution.coolant_temperature_c,
-            max_core_surface_delta_c=thermal_solution.max_core_surface_delta_c,
-        )
-        return BatteryTierMetrics(
-            cell_count=base_metrics.cell_count,
-            connection_count=base_metrics.connection_count,
-            cost_usd=base_metrics.cost_usd,
-            design_volume_mm3=base_metrics.design_volume_mm3,
-            max_temperature_c=thermal_solution.max_core_temperature_c,
-            voltage_v=base_metrics.voltage_v,
-            capacity_ah=base_metrics.capacity_ah,
-            current_limit_a=base_metrics.current_limit_a,
-            min_clearance_mm=base_metrics.min_clearance_mm,
-            is_feasible=base_metrics.failure_reason is None,
-            failure_reason=base_metrics.failure_reason,
-        )
 
 
 class _ProjectedTier3CircuitEvaluationMixin:
@@ -2024,9 +1811,6 @@ class Battery18650T3ATopologySurrogateOptimizationProblem(
             ),
         )
 
-    def _surrogate_parallel_equivalent(self, decoded: Tier3DecodedCandidate) -> float:
-        return _stage_parallel_equivalent(decoded.stage_counts, self.imbalance_model)
-
     def _thermal_config(self) -> BatteryThermalPromotionConfig:
         return _battery_thermal_config(
             cooling_coefficient_w_per_m2k=self.cooling_coefficient_w_per_m2k,
@@ -2270,14 +2054,6 @@ class Battery18650T4ThermalHybridOptimizationProblem(
     def _load_thermal_priors(self) -> BatteryThermalPriors:
         """Return the backend-aware thermal-prior bundle for this problem instance."""
         return load_battery_thermal_priors(self.backend_config)
-
-    def _analytic_thermal_defaults(self) -> tuple[float, float, float]:
-        """Return the canonical thermal proxy inputs for analytic surrogate scoring."""
-        return (
-            float(self.cooling_coefficient_w_per_m2k),
-            float(self.passive_cooling_w_per_k),
-            float(self.ambient_temperature_c),
-        )
 
     @classmethod
     def from_manifest(cls, manifest: ProblemManifest) -> Battery18650T4ThermalHybridOptimizationProblem:

--- a/src/design_research_problems/problems/_decision.py
+++ b/src/design_research_problems/problems/_decision.py
@@ -555,7 +555,6 @@ def parse_structured_decision_payload(parameters: Mapping[str, object]) -> _Pars
 
     variable_symbols = {spec.symbol for spec in decision_variable_specs}
     factor_keys = {factor.key for factor in option_factors}
-    choice_keys = {benchmark.key for benchmark in choice_benchmarks}
     symbolic_names = variable_symbols | factor_keys
     if choice_benchmarks:
         symbolic_names.add("material")
@@ -614,11 +613,6 @@ def parse_structured_decision_payload(parameters: Mapping[str, object]) -> _Pars
     for profile in competitor_profiles:
         if set(profile.values) != factor_key_set or len(profile.values) != len(ordered_factor_keys):
             raise ValueError(f"Decision profile {profile.name!r} must include exactly the option factor keys.")
-    if choice_benchmarks and response_count <= 0:
-        raise ValueError("choice_options require a positive response_count.")
-    if len(choice_keys) != len(choice_benchmarks):
-        raise ValueError("choice_options contain duplicate keys.")
-
     return _ParsedDecisionPayload(
         decision_variable_specs=decision_variable_specs,
         option_factors=option_factors,

--- a/src/design_research_problems/problems/_domains/battery_circuit.py
+++ b/src/design_research_problems/problems/_domains/battery_circuit.py
@@ -676,8 +676,6 @@ def validate_battery_circuit_state(
         return "Terminal identifiers must be unique."
 
     for cell in state.cells:
-        if cell.negative_terminal_id == cell.positive_terminal_id:
-            return "A cell cannot reuse the same terminal id for both polarities."
         if not coordinate_is_in_bounds((cell.x, cell.y, cell.z), requirements):
             return "A cell lies outside the legal grid envelope."
 

--- a/src/design_research_problems/problems/_mcp_problem.py
+++ b/src/design_research_problems/problems/_mcp_problem.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import os
 import sys
 from collections.abc import Mapping, Sequence
 from contextlib import AsyncExitStack
@@ -52,6 +53,11 @@ def _resolve_stdio_command(command: str) -> str:
     if command == "__python_executable__":
         return sys.executable
     return command
+
+
+def _merged_subprocess_env(overrides: Mapping[str, str]) -> dict[str, str]:
+    """Return the inherited environment with problem-specific overrides."""
+    return {**os.environ, **overrides}
 
 
 def parse_mcp_stdio_parameters(parameters: Mapping[str, object]) -> MCPStdioConfig:
@@ -203,7 +209,7 @@ class _LoopBoundUpstreamSession:
                 command=self._stdio_config.command,
                 args=list(self._stdio_config.args),
                 cwd=self._stdio_config.cwd,
-                env=dict(self._stdio_config.env) if self._stdio_config.env else None,
+                env=_merged_subprocess_env(self._stdio_config.env),
             )
 
             exit_stack = AsyncExitStack()
@@ -466,7 +472,7 @@ class MCPProblem(Problem):
             command=self._stdio_config.command,
             args=list(self._stdio_config.args),
             cwd=self._stdio_config.cwd,
-            env=dict(self._stdio_config.env) if self._stdio_config.env else None,
+            env=_merged_subprocess_env(self._stdio_config.env),
         )
 
         async def _discover() -> tuple[MCPTool, ...]:

--- a/src/design_research_problems/problems/_metadata.py
+++ b/src/design_research_problems/problems/_metadata.py
@@ -178,6 +178,83 @@ class ProblemMetadata:
         return normalized in self.feature_flags
 
 
+@dataclass(frozen=True)
+class ProblemCatalogSummary:
+    """Compact problem metadata for search results and agent context windows."""
+
+    problem_id: str
+    """Stable catalog identifier."""
+    title: str
+    """Display title shown to users."""
+    kind: ProblemKind
+    """High-level problem family."""
+    summary: str
+    """Short one-paragraph problem description."""
+    tags: tuple[str, ...]
+    """Searchable descriptive tags."""
+    formulation: str | None
+    """High-level mathematical or representational formulation."""
+    design_variable_type: str | None
+    """Variable domain such as continuous, discrete, or mixed."""
+    objective_mode: str | None
+    """Objective structure such as single, multi, or qualitative."""
+    constraint_nature: str | None
+    """Constraint strictness label such as hard, soft, or informal."""
+    bounds_summary: str | None
+    """Human-readable summary of bounds or design-space limits."""
+    capabilities: tuple[str, ...]
+    """Machine-readable implementation and packaging capabilities."""
+    study_suitability: tuple[str, ...]
+    """Machine-readable study-use labels for the entry."""
+
+    @classmethod
+    def from_metadata(cls, metadata: ProblemMetadata) -> ProblemCatalogSummary:
+        """Build a compact summary from one full metadata record.
+
+        Args:
+            metadata: Full problem metadata.
+
+        Returns:
+            Compact catalog summary suitable for search results.
+        """
+        taxonomy = metadata.taxonomy
+        return cls(
+            problem_id=metadata.problem_id,
+            title=metadata.title,
+            kind=metadata.kind,
+            summary=metadata.summary,
+            tags=taxonomy.tags,
+            formulation=taxonomy.formulation,
+            design_variable_type=taxonomy.design_variable_type,
+            objective_mode=taxonomy.objective_mode,
+            constraint_nature=taxonomy.constraint_nature,
+            bounds_summary=taxonomy.bounds_summary,
+            capabilities=metadata.capabilities,
+            study_suitability=metadata.study_suitability,
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-compatible summary dictionary.
+
+        Returns:
+            Dictionary form with enum values normalized to strings.
+        """
+        return {
+            "problem_id": self.problem_id,
+            "title": self.title,
+            "kind": self.kind.value,
+            "summary": self.summary,
+            "tags": list(self.tags),
+            "formulation": self.formulation,
+            "design_variable_type": self.design_variable_type,
+            "objective_mode": self.objective_mode,
+            "constraint_nature": self.constraint_nature,
+            "bounds_summary": self.bounds_summary,
+            "capabilities": list(self.capabilities),
+            "study_suitability": list(self.study_suitability),
+        }
+
+
 KNOWN_PROBLEM_CAPABILITIES = frozenset(
     {
         "statement-markdown",

--- a/src/design_research_problems/problems/_optimization.py
+++ b/src/design_research_problems/problems/_optimization.py
@@ -96,6 +96,44 @@ class LocalSearchResult:
     """Number of objective evaluations performed."""
 
 
+def _recommended_solver_family(
+    *,
+    variable_domain: str | None,
+    constraint_nature: str | None,
+    equality_constraints: int,
+    inequality_constraints: int,
+    is_dynamic: bool,
+) -> str:
+    """Return a compact solver-family hint from catalog taxonomy.
+
+    Args:
+        variable_domain: Taxonomy variable-domain label.
+        constraint_nature: Taxonomy constraint label.
+        equality_constraints: Number of equality constraints.
+        inequality_constraints: Number of inequality constraints.
+        is_dynamic: Whether the problem changes during evaluation.
+
+    Returns:
+        Human-readable solver-family hint for routing agents.
+    """
+    domain = (variable_domain or "").lower()
+    constraint_label = (constraint_nature or "").lower()
+    has_explicit_constraints = equality_constraints > 0 or inequality_constraints > 0
+    has_hard_constraints = has_explicit_constraints or "hard" in constraint_label
+
+    if is_dynamic:
+        return "dynamic or evaluation-aware optimization; avoid assuming a stationary objective"
+    if domain == "continuous" and has_hard_constraints:
+        return "constrained continuous optimizer such as SLSQP or trust-constr"
+    if domain == "continuous":
+        return "bounded continuous optimizer or deterministic local search"
+    if domain == "discrete":
+        return "discrete or combinatorial optimizer; preserve integrality explicitly"
+    if domain == "mixed":
+        return "mixed-domain optimizer or decomposition; preserve discrete variables explicitly"
+    return "inspect metadata and problem API before selecting a solver"
+
+
 def bounded_pattern_search(
     objective: Callable[[NDArray[numpy.float64]], float],
     lower_bounds: NDArray[numpy.float64],
@@ -181,6 +219,43 @@ class OptimizationProblem(ComputableProblem[NDArray[numpy.float64], Optimization
         )
         self.constraints: list[ConstraintDefinition] = []
 
+    def solver_hints(self) -> dict[str, object]:
+        """Return compact optimization hints for solver selection.
+
+        The hints summarize machine-readable bounds, variable domain, and
+        constraint counts so an agent does not have to infer solver class from
+        prose in the design brief.
+
+        Returns:
+            JSON-compatible solver-selection hints.
+        """
+        taxonomy = self.metadata.taxonomy
+        equality_constraints = sum(1 for constraint in self.constraints if constraint.kind == "eq")
+        inequality_constraints = sum(1 for constraint in self.constraints if constraint.kind == "ineq")
+        benchmark_card = self.metadata.benchmark_card
+        return {
+            "problem_id": self.metadata.problem_id,
+            "problem_kind": self.metadata.kind.value,
+            "variable_count": int(self.bounds.lb.shape[0]),
+            "variable_domain": taxonomy.design_variable_type,
+            "lower_bounds": to_json_value(self.bounds.lb),
+            "upper_bounds": to_json_value(self.bounds.ub),
+            "bounds_summary": taxonomy.bounds_summary,
+            "objective_mode": taxonomy.objective_mode,
+            "constraint_nature": taxonomy.constraint_nature,
+            "equality_constraint_count": equality_constraints,
+            "inequality_constraint_count": inequality_constraints,
+            "is_dynamic": taxonomy.is_dynamic,
+            "baseline_solver_role": None if benchmark_card is None else benchmark_card.solver_role,
+            "recommended_solver_family": _recommended_solver_family(
+                variable_domain=taxonomy.design_variable_type,
+                constraint_nature=taxonomy.constraint_nature,
+                equality_constraints=equality_constraints,
+                inequality_constraints=inequality_constraints,
+                is_dynamic=taxonomy.is_dynamic,
+            ),
+        }
+
     def evaluate(self, variables: NDArray[numpy.float64]) -> OptimizationEvaluation:
         """Evaluate one candidate vector without invoking the solver.
 
@@ -260,11 +335,25 @@ class OptimizationProblem(ComputableProblem[NDArray[numpy.float64], Optimization
                 "report": report,
             }
 
+        def solver_hints() -> dict[str, object]:
+            """Return variable-domain and constraint hints for solver selection.
+
+            Returns:
+                MCP-ready solver-selection hints.
+            """
+            return self.solver_hints()
+
         server.add_tool(
             evaluate_tool,
             name="evaluate",
             title="Evaluate Design",
             description="Evaluate a candidate vector and return feasibility/objective metrics.",
+        )
+        server.add_tool(
+            solver_hints,
+            name="solver_hints",
+            title="Get Solver Hints",
+            description="Return variable-domain, bounds, and constraint hints for choosing a solver.",
         )
         server.add_tool(
             submit_final,

--- a/src/design_research_problems/problems/grammar/_battery_tiers.py
+++ b/src/design_research_problems/problems/grammar/_battery_tiers.py
@@ -51,11 +51,7 @@ from design_research_problems.problems._domains.battery_cell_model import (
     BatteryBackendConfig,
 )
 from design_research_problems.problems._domains.battery_circuit import BatteryCircuitState
-from design_research_problems.problems._domains.battery_layout import (
-    CELL_SPEC_18650,
-    MIN_SPACING_MM,
-    BatteryRequirements,
-)
+from design_research_problems.problems._domains.battery_layout import BatteryRequirements
 from design_research_problems.problems._domains.battery_series_parallel import SeriesParallelBatteryState
 from design_research_problems.problems._domains.battery_tier_metrics import (
     BatteryTierMetrics,
@@ -109,91 +105,11 @@ class _VectorGrammarConfig:
 
 
 class Battery18650Tier1SeriesParallelGrammarProblem(BatteryPack18650SeriesParallelProblem):
-    """Tier-1 grammar: constrained rectangular ``SxP`` edits."""
-
-    @classmethod
-    def from_manifest(cls, manifest: ProblemManifest) -> Battery18650Tier1SeriesParallelGrammarProblem:
-        """Build tier-1 grammar from manifest data."""
-        return cls(
-            metadata=manifest.metadata,
-            statement_markdown=manifest.statement_markdown,
-            resource_bundle=cls.resource_bundle_from_manifest(manifest),
-            requirements=parse_battery_requirements(manifest),
-            backend_config=parse_battery_backend_config(manifest),
-        )
-
-    def evaluate(self, state: object) -> BatteryTierMetrics:  # type: ignore[override]
-        """Evaluate one tier-1 state and return the shared metric contract."""
-        evaluation = super().evaluate(state)
-        parallel_count = max(1, int(evaluation.parallel_count))
-        series_count = max(1, int(evaluation.series_count))
-        connection_count = float(max(0, series_count + 1) * max(0, parallel_count - 1))
-        per_cell_current = self.requirements.minimum_current_a / float(parallel_count)
-        total_heat_w = float(evaluation.cell_count) * (per_cell_current**2) * CELL_SPEC_18650.internal_resistance_ohm
-        cooling_conductance = 1.0 + (18.0 * float(evaluation.surface_area) * 1.0e-6)
-        max_temperature_c = 25.0 + (total_heat_w / max(cooling_conductance, 1.0e-9))
-        return BatteryTierMetrics(
-            cell_count=float(evaluation.cell_count),
-            connection_count=connection_count,
-            cost_usd=float(evaluation.design_cost),
-            design_volume_mm3=float(evaluation.design_volume),
-            max_temperature_c=max_temperature_c,
-            voltage_v=float(evaluation.design_voltage),
-            capacity_ah=float(evaluation.design_capacity),
-            current_limit_a=float(evaluation.analytic_current_limit),
-            min_clearance_mm=float(MIN_SPACING_MM),
-            is_feasible=bool(evaluation.is_feasible),
-            failure_reason=evaluation.failure_reason,
-        )
+    """Shared rectangular-edit behavior for concrete tier-1 grammars."""
 
 
 class Battery18650Tier3TopologyGrammarProblem(BatteryPack18650OpenEndedProblem):
-    """Tier-3 grammar: explicit circuit topology edits with variable cell count."""
-
-    @classmethod
-    def from_manifest(cls, manifest: ProblemManifest) -> Battery18650Tier3TopologyGrammarProblem:
-        """Build tier-3 grammar from manifest data."""
-        return cls(
-            metadata=manifest.metadata,
-            statement_markdown=manifest.statement_markdown,
-            resource_bundle=cls.resource_bundle_from_manifest(manifest),
-            requirements=parse_battery_requirements(manifest),
-            max_cell_count=int(cast(int, manifest.parameters.get("max_cell_count", 24))),
-            backend_config=parse_battery_backend_config(manifest),
-        )
-
-    def evaluate(self, state: object) -> BatteryTierMetrics:  # type: ignore[override]
-        """Evaluate one tier-3 state and return the shared metric contract."""
-        evaluation = super().evaluate(state)
-        delivered_capacity = (
-            0.0 if evaluation.delivered_capacity_ah is None else float(evaluation.delivered_capacity_ah)
-        )
-        nominal_voltage = float(evaluation.pack_nominal_voltage)
-        max_cell_current = 0.0 if evaluation.max_cell_current_a is None else float(evaluation.max_cell_current_a)
-        parallel_equivalent = max(delivered_capacity / max(CELL_SPEC_18650.nominal_capacity_ah, 1.0e-9), 1.0)
-        total_heat_w = (
-            float(evaluation.cell_count)
-            * ((self.requirements.minimum_current_a / parallel_equivalent) ** 2)
-            * CELL_SPEC_18650.internal_resistance_ohm
-        )
-        cooling_conductance = 1.0 + (18.0 * float(evaluation.surface_area) * 1.0e-6)
-        max_temperature_c = 25.0 + (total_heat_w / max(cooling_conductance, 1.0e-9))
-        min_clearance = MIN_SPACING_MM if evaluation.is_feasible else -MIN_SPACING_MM
-        return BatteryTierMetrics(
-            cell_count=float(evaluation.cell_count),
-            connection_count=float(evaluation.connection_count),
-            cost_usd=float(evaluation.design_cost),
-            design_volume_mm3=float(evaluation.design_volume),
-            max_temperature_c=max_temperature_c,
-            voltage_v=nominal_voltage,
-            capacity_ah=delivered_capacity,
-            current_limit_a=max(
-                max_cell_current, self.requirements.minimum_current_a if evaluation.is_feasible else 0.0
-            ),
-            min_clearance_mm=float(min_clearance),
-            is_feasible=bool(evaluation.is_feasible),
-            failure_reason=evaluation.failure_reason,
-        )
+    """Shared explicit-netlist editing behavior for concrete tier-3 grammars."""
 
 
 class Battery18650Tier2LayoutGrammarProblem(GrammarProblem[tuple[float, ...], BatteryTierMetrics]):

--- a/tests/test_battery_circuit_backend.py
+++ b/tests/test_battery_circuit_backend.py
@@ -21,6 +21,7 @@ from design_research_problems.problems._domains.battery_circuit import (
     BatteryConnection,
     analyze_battery_topology,
     evaluate_battery_circuit,
+    validate_battery_circuit_state,
 )
 from design_research_problems.problems._domains.battery_layout import (
     CELL_SPEC_18650,
@@ -177,6 +178,70 @@ def _single_cell_state() -> BatteryCircuitState:
         pack_positive_terminal_id=1,
         pack_negative_terminal_id=0,
     )
+
+
+def test_circuit_validation_reports_each_structural_input_error() -> None:
+    requirements = _relaxed_requirements(target_voltage_v=3.7, minimum_capacity_ah=1.0, minimum_current_a=1.0)
+    valid = _single_cell_state()
+    cell = valid.cells[0]
+
+    cases = [
+        (replace(valid, cells=()), "At least one battery cell"),
+        (replace(valid, cells=(cell, replace(cell, x=1))), "Cell identifiers must be unique"),
+        (
+            replace(valid, cells=(cell, replace(cell, cell_id=1, x=1))),
+            "Terminal identifiers must be unique",
+        ),
+        (replace(valid, cells=(replace(cell, x=999),)), "outside the legal grid envelope"),
+        (
+            replace(
+                valid,
+                cells=(cell, replace(cell, cell_id=1, positive_terminal_id=3, negative_terminal_id=2)),
+            ),
+            "Duplicate physical coordinates",
+        ),
+        (replace(valid, pack_positive_terminal_id=0), "Pack positive and negative terminals must be distinct"),
+        (replace(valid, pack_positive_terminal_id=999), "Pack terminals must reference existing"),
+    ]
+
+    base_connection = BatteryConnection(connection_id=0, from_terminal_id=0, to_terminal_id=1)
+    two_cell = _two_cell_series_state()
+    cases.extend(
+        [
+            (
+                replace(
+                    two_cell,
+                    connections=(two_cell.connections[0], replace(two_cell.connections[0], ideal=False)),
+                ),
+                "Connection identifiers must be unique",
+            ),
+            (replace(valid, connections=(replace(base_connection, to_terminal_id=0),)), "join two distinct terminals"),
+            (replace(valid, connections=(replace(base_connection, to_terminal_id=999),)), "reference existing"),
+            (replace(valid, connections=(replace(base_connection, resistance_ohm=0),)), "positive resistance"),
+            (
+                replace(
+                    valid,
+                    connections=(base_connection, replace(base_connection, connection_id=1, ideal=True)),
+                ),
+                "Duplicate direct connections",
+            ),
+            (
+                replace(
+                    two_cell,
+                    connections=(
+                        *two_cell.connections,
+                        BatteryConnection(connection_id=1, from_terminal_id=2, to_terminal_id=3),
+                    ),
+                ),
+                "cell cannot have its terminals shorted",
+            ),
+        ]
+    )
+
+    for state, expected in cases:
+        reason = validate_battery_circuit_state(state, requirements)
+        assert reason is not None
+        assert expected in reason
 
 
 def _two_cell_series_state() -> BatteryCircuitState:
@@ -1184,6 +1249,130 @@ def test_two_rc_trace_residuals_accept_tuple_voltage_trace() -> None:
     assert numpy.allclose(residuals, 0.0)
 
 
+def test_two_rc_identification_adapter_builds_and_fits_traces(monkeypatch: pytest.MonkeyPatch) -> None:
+    from design_research_problems.problems._domains import battery_cell_model as battery_cell_model
+
+    class _Solution:
+        t = numpy.array([0.0, 2.0])
+
+        def __getitem__(self, name: str) -> object:
+            value = 1.5 if name == "Current [A]" else 3.8
+            return lambda times: numpy.full(numpy.asarray(times).shape, value)
+
+    class _Simulation:
+        def __init__(self, model: object, **kwargs: object) -> None:
+            del model, kwargs
+
+        def solve(self, *, initial_soc: float) -> _Solution:
+            assert initial_soc in battery_cell_model._TWO_RC_IDENTIFICATION_SOC_GRID
+            return _Solution()
+
+    defaults = {
+        "Nominal cell capacity [A.h]": 2.5,
+        "Initial temperature [K]": 298.15,
+    }
+    fake_pybamm = SimpleNamespace(
+        lithium_ion=SimpleNamespace(SPM=lambda: SimpleNamespace(default_parameter_values=dict(defaults))),
+        Experiment=lambda steps: tuple(steps),
+        Simulation=_Simulation,
+    )
+    monkeypatch.setattr(battery_cell_model, "import_pybamm", lambda: fake_pybamm)
+
+    short_steps = battery_cell_model._build_two_rc_identification_experiment_steps(include_long_rest=False)
+    long_steps = battery_cell_model._build_two_rc_identification_experiment_steps(include_long_rest=True)
+    assert len(short_steps) == 8
+    assert long_steps[-1] == "Rest for 300 seconds"
+
+    traces = battery_cell_model._generate_pybamm_two_rc_identification_traces(resolved_parameter_set=None)
+    assert len(traces) == 15
+    assert traces[0].time_s == (0.0, 1.0, 2.0)
+    assert traces[0].current_a == (1.5, 1.5, 1.5)
+
+    monkeypatch.setattr(
+        battery_cell_model,
+        "_load_named_parameter_values",
+        lambda **kwargs: dict(defaults),
+    )
+    named_traces = battery_cell_model._generate_pybamm_two_rc_identification_traces(resolved_parameter_set="test-set")
+    assert len(named_traces) == len(traces)
+
+    monkeypatch.setattr(battery_cell_model, "import_pybamm", lambda: SimpleNamespace())
+    with pytest.raises(MissingOptionalDependencyError, match=r"lithium_ion\.SPM"):
+        battery_cell_model._generate_pybamm_two_rc_identification_traces(resolved_parameter_set=None)
+    monkeypatch.setattr(battery_cell_model, "import_pybamm", lambda: fake_pybamm)
+
+    fitted = SimpleNamespace(success=True, x=numpy.array([0.01, 0.02, 8.0, 0.03, 120.0]))
+    monkeypatch.setattr("scipy.optimize.least_squares", lambda *args, **kwargs: fitted)
+    result = battery_cell_model._fit_two_rc_trace(
+        traces[0],
+        parameter_values=defaults,
+        resistance_scale=2.0,
+        open_circuit_voltage_v=tuple(4.0 for _ in battery_cell_model._TWO_RC_REFERENCE_SOC_GRID),
+    )
+    assert result.series_resistance_ohm == pytest.approx(0.02)
+    assert result.transient_capacitance_f == pytest.approx(200.0)
+    assert result.secondary_transient_capacitance_f == pytest.approx(2000.0)
+
+    monkeypatch.setattr(
+        "scipy.optimize.least_squares",
+        lambda *args, **kwargs: SimpleNamespace(success=False, x=fitted.x),
+    )
+    with pytest.raises(MissingOptionalDependencyError, match="did not converge"):
+        battery_cell_model._fit_two_rc_trace(
+            traces[0],
+            parameter_values=defaults,
+            resistance_scale=1.0,
+            open_circuit_voltage_v=tuple(4.0 for _ in battery_cell_model._TWO_RC_REFERENCE_SOC_GRID),
+        )
+
+
+def test_two_rc_ocv_and_dynamic_interpolation_adapters(monkeypatch: pytest.MonkeyPatch) -> None:
+    from design_research_problems.problems._domains import battery_cell_model as battery_cell_model
+
+    direct = battery_cell_model._build_reference_ocv_lookup(
+        parameter_values={"Open-circuit voltage [V]": lambda temperature_k, current_a, soc: 3.0 + soc},
+        resolved_parameter_set=None,
+    )
+    assert direct[0] == pytest.approx(3.0)
+    assert direct[-1] == pytest.approx(4.0)
+
+    class _Solution:
+        def __getitem__(self, name: str) -> object:
+            assert name == "Voltage [V]"
+            return lambda _time: 3.75
+
+    fake_pybamm = SimpleNamespace(
+        lithium_ion=SimpleNamespace(
+            SPM=lambda: SimpleNamespace(default_parameter_values={"Initial temperature [K]": 298.15})
+        ),
+        Experiment=lambda steps: tuple(steps),
+        Simulation=lambda *args, **kwargs: SimpleNamespace(solve=lambda **solve_kwargs: _Solution()),
+    )
+    monkeypatch.setattr(battery_cell_model, "import_pybamm", lambda: fake_pybamm)
+    fallback = battery_cell_model._build_reference_ocv_lookup(parameter_values={}, resolved_parameter_set=None)
+    assert fallback == pytest.approx((3.75,) * 11)
+
+    model = replace(
+        _static_two_rc_cell_model(),
+        dynamic_parameters=battery_cell_model._BatteryCellDynamicParameters(
+            parameter_values={},
+            open_circuit_voltage_fn=lambda temperature_k, current_a, soc: 3.0 + soc,
+            resistance_scale=2.0,
+            resistance_normalization=0.5,
+            capacitance_normalization=2.0,
+            secondary_capacitance_normalization=2.0,
+            temperature_grid_c=(15.0, 35.0),
+            series_resistance_by_temperature_ohm=((0.02,) * 11, (0.04,) * 11),
+            transient_resistance_by_temperature_ohm=((0.03,) * 11, (0.05,) * 11),
+            transient_capacitance_by_temperature_f=((100.0,) * 11, (200.0,) * 11),
+            secondary_transient_resistance_by_temperature_ohm=((0.01,) * 11, (0.03,) * 11),
+            secondary_transient_capacitance_by_temperature_f=((800.0,) * 11, (1200.0,) * 11),
+        ),
+    )
+    interpolated = battery_cell_model.interpolate_cell_model(model, 0.5, temperature_c=25.0)
+    assert interpolated == pytest.approx((3.5, 0.03, 0.04, 37.5, 0.02, 250.0))
+
+
 def test_evaluate_battery_circuit_uses_pybamm_direct_path(monkeypatch: pytest.MonkeyPatch) -> None:
     from design_research_problems.problems._domains import battery_circuit as battery_circuit
 
@@ -1236,6 +1425,94 @@ def test_evaluate_battery_circuit_uses_pybamm_direct_path(monkeypatch: pytest.Mo
     assert evaluation.cell_model_source == "pybamm_spm_direct"
     assert evaluation.cell_model_parameter_set == "Marquis2019"
     assert evaluation.pack_terminal_voltage_end == pytest.approx(7.8)
+
+
+def test_pybamm_direct_adapter_runs_without_the_optional_solver(monkeypatch: pytest.MonkeyPatch) -> None:
+    from design_research_problems.problems._domains import battery_circuit as battery_circuit
+
+    class _Solution:
+        t = numpy.array([0.0, 1.0])
+        termination = "final time"
+
+        def __getitem__(self, name: str) -> object:
+            if name == "Voltage [V]":
+                return lambda times: numpy.full(numpy.asarray(times).shape, 3.9)
+            if name == "Volume-averaged cell temperature [K]":
+                return lambda times: numpy.full((len(numpy.asarray(times)), 2), 300.15)
+            if name == "Irreversible electrochemical heating [W]":
+                return lambda times: numpy.full(numpy.asarray(times).shape, 0.2)
+            raise KeyError(name)
+
+    model_options: list[object] = []
+
+    def _spm(*, options: object = None) -> object:
+        model_options.append(options)
+        return object()
+
+    fake_pybamm = SimpleNamespace(
+        lithium_ion=SimpleNamespace(SPM=_spm),
+        Experiment=lambda steps: tuple(steps),
+        Simulation=lambda *args, **kwargs: SimpleNamespace(solve=lambda **solve_kwargs: _Solution()),
+    )
+    monkeypatch.setattr(battery_circuit, "import_pybamm", lambda: fake_pybamm)
+    monkeypatch.setattr(
+        battery_circuit,
+        "_load_lithium_ion_parameter_values",
+        lambda **kwargs: ({}, 1.0, 298.15),
+    )
+
+    state = _single_cell_state()
+    requirements = _relaxed_requirements(
+        target_voltage_v=3.7,
+        minimum_capacity_ah=1.0 / 3600.0,
+        minimum_current_a=1.0,
+    )
+    result, source, parameter_set = battery_circuit._simulate_battery_circuit_pybamm_direct(
+        state,
+        requirements,
+        analyze_battery_topology(state),
+        simulate_to_failure=False,
+        backend_config=BatteryBackendConfig(
+            parameterization=BatteryParameterization(parameter_set="test-set"),
+            thermal_mode="lumped",
+        ),
+    )
+    assert source == "pybamm_spm_direct"
+    assert parameter_set == "test-set"
+    assert result.is_feasible is True
+    assert result.pack_terminal_voltage_end == pytest.approx(3.9)
+    assert result.end_cell_temperature_c == pytest.approx(27.0)
+    assert result.cumulative_cell_heat_j == pytest.approx(0.2)
+    assert model_options == [{"thermal": "lumped"}]
+
+    with pytest.raises(ValueError, match="does not support thermal_mode"):
+        battery_circuit._simulate_battery_circuit_pybamm_direct(
+            state,
+            requirements,
+            analyze_battery_topology(state),
+            simulate_to_failure=False,
+            backend_config=BatteryBackendConfig(thermal_mode="x-full"),
+        )
+
+
+def test_pybamm_direct_helpers_report_unsupported_states_and_missing_traces() -> None:
+    from design_research_problems.problems._domains import battery_circuit as battery_circuit
+
+    state = _single_cell_state()
+    analysis = analyze_battery_topology(state)
+    unsupported = SimpleNamespace(topology_kind="custom", series_count=None, parallel_count=None)
+    assert "series-parallel" in battery_circuit._validate_pybamm_direct_state(state, unsupported)
+    assert "at least one active cell" in battery_circuit._validate_pybamm_direct_state(
+        replace(state, cells=()), analysis
+    )
+
+    sample_times = numpy.array([0.0, 1.0])
+    with pytest.raises(KeyError, match="temperature variable"):
+        battery_circuit._load_pybamm_direct_temperature_trace_c({}, sample_times)
+    assert numpy.array_equal(
+        battery_circuit._load_pybamm_direct_heat_trace_w({}, sample_times),
+        numpy.zeros(2),
+    )
 
 
 def test_pybamm_direct_rejects_nonideal_interconnect_topologies() -> None:

--- a/tests/test_battery_helper_coverage.py
+++ b/tests/test_battery_helper_coverage.py
@@ -7,9 +7,11 @@ import numpy
 import pytest
 
 from design_research_problems._catalog._manifest import ProblemManifest
+from design_research_problems._exceptions import MissingOptionalDependencyError
 from design_research_problems.problems import _battery_adapters as battery_adapters
 from design_research_problems.problems import _battery_problem_config as battery_problem_config
 from design_research_problems.problems import _battery_tier_problems as battery_tier_problems
+from design_research_problems.problems._domains import battery_cell_model as cell_model
 from design_research_problems.problems._domains.battery_benchmark import BatteryEvaluationMode
 from design_research_problems.problems._domains.battery_cell_model import BatteryBackendConfig, BatteryThermalPriors
 from design_research_problems.problems._domains.battery_core import (
@@ -137,6 +139,176 @@ def _fake_circuit_evaluation(**overrides: object) -> SimpleNamespace:
     }
     values.update(overrides)
     return SimpleNamespace(**values)
+
+
+def test_battery_cell_parameter_helpers_cover_backend_shape_variations() -> None:
+    assert cell_model.battery_backend_config_from_mapping(None).cell_model_mode == "auto"
+    with pytest.raises(ValueError, match="must be a mapping"):
+        cell_model.battery_backend_config_from_mapping("invalid")
+
+    with pytest.raises(MissingOptionalDependencyError, match="ParameterValues support"):
+        cell_model._load_named_parameter_values(pybamm_module=object(), parameter_set="missing")
+
+    failing_module = SimpleNamespace(ParameterValues=lambda _name: (_ for _ in ()).throw(RuntimeError("missing")))
+    with pytest.raises(MissingOptionalDependencyError, match="could not be loaded"):
+        cell_model._load_named_parameter_values(pybamm_module=failing_module, parameter_set="missing")
+
+    copied = object()
+    source = SimpleNamespace(copy=lambda: copied)
+    assert cell_model._copy_parameter_values(source) is copied
+    assert cell_model._copy_parameter_values(copied) is copied
+
+    mutable: dict[str, float] = {}
+    cell_model._try_set_parameter_value(mutable, "value", 2.0)
+    assert mutable["value"] == 2.0
+
+    class _FallbackMutable(dict[str, float]):
+        def update(self, *_args: object, **_kwargs: object) -> None:
+            raise RuntimeError("unsupported")
+
+    fallback_mutable = _FallbackMutable()
+    cell_model._try_set_parameter_value(fallback_mutable, "value", 3.0)
+    assert fallback_mutable["value"] == 3.0
+    cell_model._try_set_parameter_value(object(), "value", 4.0)
+
+
+def test_battery_cell_mapping_and_parameter_function_fallbacks() -> None:
+    assert cell_model._mapping_get({"key": 1}, "key") == 1
+
+    class _ContainsOnly:
+        def __contains__(self, key: str) -> bool:
+            return key == "key"
+
+        def __getitem__(self, key: str) -> int:
+            assert key == "key"
+            return 2
+
+    assert cell_model._mapping_get(_ContainsOnly(), "key") == 2
+    assert cell_model._mapping_get(object(), "key", 3) == 3
+
+    class _BrokenContains:
+        def __contains__(self, _key: str) -> bool:
+            raise RuntimeError("broken")
+
+    assert cell_model._mapping_get(_BrokenContains(), "key", 4) == 4
+
+    calls: list[tuple[object, ...]] = []
+
+    def _one_argument(*args: object) -> float:
+        calls.append(args)
+        if len(args) != 1:
+            raise TypeError
+        return 5.0
+
+    assert (
+        cell_model._evaluate_parameter_function(
+            parameter_values={},
+            function_or_value=_one_argument,
+            ambient_temperature_k=298.15,
+            soc=0.5,
+            default=1.0,
+        )
+        == 5.0
+    )
+    assert len(calls) == 3
+
+    def _always_fails(*_args: object) -> float:
+        raise RuntimeError("cannot evaluate")
+
+    assert (
+        cell_model._evaluate_parameter_function(
+            parameter_values={},
+            function_or_value=_always_fails,
+            ambient_temperature_k=298.15,
+            soc=0.5,
+            default=1.0,
+        )
+        == 1.0
+    )
+    with pytest.raises(MissingOptionalDependencyError, match="could not be evaluated"):
+        cell_model._evaluate_parameter_function(
+            parameter_values={},
+            function_or_value=_always_fails,
+            ambient_temperature_k=298.15,
+            soc=0.5,
+            default=1.0,
+            strict=True,
+            parameter_name="R0",
+        )
+
+    assert (
+        cell_model._evaluate_parameter_function(
+            parameter_values={},
+            function_or_value=None,
+            ambient_temperature_k=298.15,
+            soc=0.5,
+            default=2.0,
+        )
+        == 2.0
+    )
+    with pytest.raises(MissingOptionalDependencyError, match="do not expose"):
+        cell_model._evaluate_parameter_function(
+            parameter_values={},
+            function_or_value=None,
+            ambient_temperature_k=298.15,
+            soc=0.5,
+            default=2.0,
+            strict=True,
+            parameter_name="R1",
+        )
+
+    evaluator = SimpleNamespace(evaluate=lambda _value: (_ for _ in ()).throw(RuntimeError("bad")))
+    assert (
+        cell_model._evaluate_parameter_function(
+            parameter_values=evaluator,
+            function_or_value=object(),
+            ambient_temperature_k=298.15,
+            soc=0.5,
+            default=3.0,
+        )
+        == 3.0
+    )
+    with pytest.raises(MissingOptionalDependencyError, match="could not be evaluated"):
+        cell_model._evaluate_parameter_function(
+            parameter_values=evaluator,
+            function_or_value=object(),
+            ambient_temperature_k=298.15,
+            soc=0.5,
+            default=3.0,
+            strict=True,
+            parameter_name="scalar",
+        )
+
+
+def test_battery_cell_interpolation_and_parameterization_boundaries() -> None:
+    priors = _thermal_priors()
+    assert cell_model.interpolate_total_resistance(priors, -1.0) == pytest.approx(0.05)
+    assert cell_model.interpolate_total_resistance(priors, 2.0) == pytest.approx(0.05)
+    assert cell_model.interpolate_total_resistance(priors, 0.5) == pytest.approx(0.05)
+
+    assert cell_model._interpolate_temperature_lookup((), (), 0.5, temperature_c=25, default=7) == 7.0
+    assert (
+        cell_model._interpolate_temperature_lookup(
+            (10.0, 20.0),
+            ((1.0,),),
+            0.5,
+            temperature_c=15,
+            default=8,
+        )
+        == 8.0
+    )
+
+    assert cell_model._parse_parameterization({"parameterization": " FAST "}).preset == "fast"
+    with pytest.raises(ValueError, match="mapping or string"):
+        cell_model._parse_parameterization({"parameterization": 2})
+    with pytest.raises(ValueError, match="Unsupported battery parameterization"):
+        cell_model._normalize_parameterization(cell_model.BatteryParameterization(preset="invalid"))
+    normalized = cell_model._normalize_parameterization(cell_model.BatteryParameterization(parameter_set=" "))
+    assert normalized.parameter_set is None
+    with pytest.raises(ValueError, match="must be a string"):
+        cell_model._coerce_string(2, field_name="field")
+    with pytest.raises(ValueError, match="must not be empty"):
+        cell_model._coerce_string(" ", field_name="field")
 
 
 def test_battery_problem_config_helpers_cover_defaults_and_backend_parsing() -> None:

--- a/tests/test_build123d_cad_coverage.py
+++ b/tests/test_build123d_cad_coverage.py
@@ -28,6 +28,36 @@ class _DummyShape:
         return True
 
 
+class _NullContext:
+    """Context manager used by the in-memory Build123d protocol double."""
+
+    def __init__(self, *_args: object) -> None:
+        pass
+
+    def __enter__(self) -> _NullContext:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+
+class _BracketEdge:
+    """Edge double positioned at the bracket's internal corner."""
+
+    def center(self) -> SimpleNamespace:
+        return SimpleNamespace(Y=-14.0, Z=6.0)
+
+
+class _BracketPart(_NullContext):
+    """BuildPart double exposing the subset consumed by the adapter."""
+
+    def __init__(self) -> None:
+        self.part = SimpleNamespace(volume=41_000.0)
+
+    def edges(self) -> list[_BracketEdge]:
+        return [_BracketEdge()]
+
+
 def test_normalize_mounting_bracket_spec_validates_inputs() -> None:
     spec = cad.MountingBracketSpec()
     assert cad.normalize_mounting_bracket_spec(spec) is spec
@@ -177,6 +207,44 @@ def test_build123d_bracket_volume_raises_when_dependency_missing(monkeypatch: py
     monkeypatch.setattr(cad, "import_module", _raise_import)
     with pytest.raises(RuntimeError, match="build123d is not installed"):
         cad._build123d_bracket_volume_mm3(cad.MountingBracketSpec())
+
+
+def test_build123d_bracket_volume_uses_backend_protocol(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bracket construction should use the documented Build123d primitive protocol."""
+    primitive_calls: list[tuple[str, tuple[object, ...], dict[str, object]]] = []
+    fillet_radii: list[float] = []
+
+    def _record_primitive(name: str):
+        def _primitive(*args: object, **kwargs: object) -> None:
+            primitive_calls.append((name, args, kwargs))
+
+        return _primitive
+
+    def _fillet(_edges: object, radius: float) -> None:
+        fillet_radii.append(radius)
+        if len(fillet_radii) == 1:
+            raise ValueError("requested radius is infeasible")
+
+    fake_module = SimpleNamespace(
+        BuildPart=_BracketPart,
+        Box=_record_primitive("box"),
+        Cylinder=_record_primitive("cylinder"),
+        Locations=_NullContext,
+        Location=lambda *args: args,
+        fillet=_fillet,
+        Align=SimpleNamespace(CENTER="center", MIN="min"),
+        Mode=SimpleNamespace(SUBTRACT="subtract"),
+    )
+    monkeypatch.setattr(cad, "import_module", lambda _name: fake_module)
+
+    volume, applied_fillet, warning = cad._build123d_bracket_volume_mm3(cad.MountingBracketSpec())
+
+    assert volume == pytest.approx(41_000.0)
+    assert applied_fillet == pytest.approx(3.5)
+    assert warning == "Requested 4 mm fillet; applied feasible 3.5 mm."
+    assert [call[0] for call in primitive_calls].count("box") == 2
+    assert [call[0] for call in primitive_calls].count("cylinder") == 6
+    assert fillet_radii == [4.0, 3.5]
 
 
 def test_build123d_bracket_volume_with_optional_backend() -> None:

--- a/tests/test_build123d_cad_coverage.py
+++ b/tests/test_build123d_cad_coverage.py
@@ -53,6 +53,11 @@ def test_geometry_helpers_return_deterministic_layouts() -> None:
     assert cad._flange_hole_centers_z(cad.MountingBracketSpec(flange_hole_count=0)) == []
     assert cad._fillet_candidates_mm(0.0) == []
     assert cad._fillet_candidates_mm(1.0) == [1.0, 0.5]
+    assert cad._base_hole_centers_xy(cad.MountingBracketSpec(base_hole_count=1)) == [(0.0, 0.0)]
+    assert len(cad._base_hole_centers_xy(cad.MountingBracketSpec(base_hole_count=2))) == 2
+    assert len(cad._flange_hole_centers_z(cad.MountingBracketSpec(flange_hole_count=1))) == 1
+    assert len(cad._flange_hole_centers_z(cad.MountingBracketSpec(flange_hole_count=3))) == 3
+    assert cad._fillet_candidates_mm(0.75) == [0.75, 0.5]
 
 
 def test_render_build123d_script_embeds_parameter_values() -> None:
@@ -134,6 +139,37 @@ def test_evaluate_scripted_part_validates_preconditions_and_output(monkeypatch: 
         cad.evaluate_scripted_part("raise ValueError('boom')")
 
 
+@pytest.mark.parametrize(
+    "script",
+    [
+        "import os",
+        "from . import Box",
+        "from os import path",
+        "from build123d import *",
+        "open('file.txt')",
+        "object.__subclasses__()",
+        "value = object.__class__",
+        "value = __builtins__",
+        "global value",
+    ],
+)
+def test_script_validator_rejects_unsafe_python_features(script: str) -> None:
+    with pytest.raises(ValueError):
+        cad._validate_build123d_script(script)
+
+
+def test_script_validator_and_import_hook_report_syntax_and_import_errors() -> None:
+    with pytest.raises(ValueError, match="invalid Python syntax"):
+        cad._validate_build123d_script("if:")
+    with pytest.raises(ImportError, match="Relative imports"):
+        cad._safe_script_import("build123d", level=1)
+    with pytest.raises(ImportError, match="is not allowed"):
+        cad._safe_script_import("os")
+    assert cad._safe_script_import("math") is not None
+    assert "line 1" in str(cad._script_restriction_error("restricted", cad.ast.parse("x = 1").body[0]))
+    assert str(cad._script_restriction_error("restricted")) == "restricted"
+
+
 def test_build123d_bracket_volume_raises_when_dependency_missing(monkeypatch: pytest.MonkeyPatch) -> None:
     def _raise_import(_name: str) -> object:
         raise ImportError("missing")
@@ -141,6 +177,35 @@ def test_build123d_bracket_volume_raises_when_dependency_missing(monkeypatch: py
     monkeypatch.setattr(cad, "import_module", _raise_import)
     with pytest.raises(RuntimeError, match="build123d is not installed"):
         cad._build123d_bracket_volume_mm3(cad.MountingBracketSpec())
+
+
+def test_build123d_bracket_volume_with_optional_backend() -> None:
+    pytest.importorskip("build123d")
+
+    volume, applied_fillet, warning = cad._build123d_bracket_volume_mm3(cad.MountingBracketSpec())
+
+    assert volume > 0.0
+    assert applied_fillet is not None
+    assert applied_fillet > 0.0
+    assert warning is None or "applied feasible" in warning
+
+
+def test_scripted_part_wraps_shape_metric_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    shape = SimpleNamespace(
+        volume=1.0,
+        area=1.0,
+        bounding_box=lambda: (_ for _ in ()).throw(RuntimeError("no bounding box")),
+        is_valid=lambda: True,
+    )
+    monkeypatch.setattr(cad, "build123d_available", lambda: True)
+    monkeypatch.setattr(
+        cad,
+        "_script_build123d_namespace",
+        lambda: {"__builtins__": {}, "shape": shape},
+    )
+
+    with pytest.raises(ValueError, match="Could not compute shape metrics"):
+        cad.evaluate_scripted_part("result = shape")
 
 
 def test_bracket_report_handles_backend_available_and_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_decision_validation_boundaries.py
+++ b/tests/test_decision_validation_boundaries.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+
+from design_research_problems.problems import _decision as decision
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda: decision.DecisionVariableSpec(" ", "label", None, 0, 1),
+        lambda: decision.DecisionVariableSpec("x", " ", None, 0, 1),
+        lambda: decision.DecisionVariableSpec("x", "label", None, 2, 1),
+        lambda: decision.DecisionFactor(" ", "label", None, (1,), ()),
+        lambda: decision.DecisionFactor("x", " ", None, (1,), ()),
+        lambda: decision.DecisionFactor("x", "label", None, (), ()),
+        lambda: decision.DecisionFactor("x", "label", None, (1, 1), ()),
+        lambda: decision.DecisionFactor("x", "label", None, (1, 2), (1,)),
+        lambda: decision.DecisionProfile(" ", {}),
+        lambda: decision.DecisionObjectiveSpec(" ", "label", "maximize", "choice", "x", (), True),
+        lambda: decision.DecisionObjectiveSpec("x", " ", "maximize", "choice", "x", (), True),
+        lambda: decision.DecisionObjectiveSpec("x", "label", " ", "choice", "x", (), True),
+        lambda: decision.DecisionObjectiveSpec("x", "label", "maximize", " ", "x", (), True),
+        lambda: decision.DecisionObjectiveSpec("x", "label", "maximize", "choice", " ", (), True),
+        lambda: decision.DecisionConstraintSpec(" ", "label", "<=", "choice", "x", (), True),
+        lambda: decision.DecisionConstraintSpec("x", " ", "<=", "choice", "x", (), True),
+        lambda: decision.DecisionConstraintSpec("x", "label", " ", "choice", "x", (), True),
+        lambda: decision.DecisionConstraintSpec("x", "label", "<=", " ", "x", (), True),
+        lambda: decision.DecisionConstraintSpec("x", "label", "<=", "choice", " ", (), True),
+        lambda: decision.DecisionChoiceBenchmark(" ", "label", 0.5, 5, 5, 1),
+        lambda: decision.DecisionChoiceBenchmark("x", " ", 0.5, 5, 5, 1),
+        lambda: decision.DecisionChoiceBenchmark("x", "label", 1.1, 5, 5, 1),
+        lambda: decision.DecisionChoiceBenchmark("x", "label", 0.5, 5, 5, -1),
+    ],
+)
+def test_decision_value_objects_reject_invalid_definitions(factory: Callable[[], object]) -> None:
+    with pytest.raises(ValueError):
+        factory()
+
+
+def _evaluation(**overrides: object) -> decision.DecisionEvaluation:
+    values: dict[str, object] = {
+        "candidate_kind": "discrete-option",
+        "candidate": decision.DecisionOption({"x": 1}),
+        "candidate_label": "candidate",
+        "objective_value": 1.0,
+        "objective_metric": "utility",
+    }
+    values.update(overrides)
+    return decision.DecisionEvaluation(**values)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"candidate_label": " "},
+        {"objective_metric": " "},
+        {"candidate_kind": "unknown"},
+        {"choice_key": " "},
+        {"choice_label": " "},
+        {"response_count": -1},
+    ],
+)
+def test_decision_evaluation_rejects_invalid_normalized_fields(overrides: dict[str, object]) -> None:
+    with pytest.raises(ValueError):
+        _evaluation(**overrides)
+
+
+def test_decision_evaluation_normalizes_all_optional_metrics() -> None:
+    result = _evaluation(
+        utility=1,
+        predicted_share=0.25,
+        expected_demand_units=10,
+        choice_key=" Choice ",
+        choice_label=" Choice label ",
+        top_choice_share=0.5,
+        mean_rating=8,
+        median_rating=9,
+        std_rating=1,
+        response_count=12,
+    )
+    assert result.choice_key == "choice"
+    assert result.choice_label == "Choice label"
+    assert result.expected_demand_units == 10.0
+    assert result.response_count == 12
+
+
+def test_natural_cubic_spline_validates_points_and_handles_each_interval_kind() -> None:
+    with pytest.raises(ValueError, match="same length"):
+        decision._NaturalCubicSpline.from_points((0, 1), (0,))
+    with pytest.raises(ValueError, match="at least one"):
+        decision._NaturalCubicSpline.from_points((), ())
+    with pytest.raises(ValueError, match="strictly increasing"):
+        decision._NaturalCubicSpline.from_points((0, 0), (0, 1))
+
+    constant = decision._NaturalCubicSpline.from_points((1,), (3,))
+    assert constant.evaluate(100) == 3
+
+    linear = decision._NaturalCubicSpline.from_points((0, 1), (0, 2))
+    assert linear.evaluate(-1) == pytest.approx(-2)
+    assert linear.evaluate(2) == pytest.approx(4)
+
+    curved = decision._NaturalCubicSpline.from_points((0, 1, 2), (0, 1, 0))
+    assert curved.evaluate(0.5) > 0
+
+
+@pytest.mark.parametrize(
+    ("call", "message"),
+    [
+        (lambda: decision._freeze_numeric_mapping({" ": 1}), "non-empty keys"),
+        (lambda: decision._normalize_string_tuple(("ok", " "), "field"), "non-empty strings"),
+        (lambda: decision._list_of_mappings("bad", "field"), "sequence of mappings"),
+        (lambda: decision._list_of_mappings((1,), "field"), "entries must be mappings"),
+        (lambda: decision._sequence("bad", "field"), "must be a sequence"),
+        (lambda: decision._required_float({}, "missing"), "Missing required numeric field"),
+        (lambda: decision._coerce_int(1.5, "field"), "must be an integer"),
+        (lambda: decision._coerce_float(" ", "field"), "must not be an empty string"),
+        (lambda: decision._coerce_float(object(), "field"), "must be numeric"),
+        (lambda: decision._solve_tridiagonal((0,), (1,), (), (1,)), "same length"),
+        (lambda: decision._solve_tridiagonal((0,), (0,), (0,), (1,)), "zero leading"),
+        (lambda: decision._solve_tridiagonal((0, 1), (1, 1), (1, 0), (1, 1)), "singular"),
+    ],
+)
+def test_decision_parsing_helpers_raise_field_specific_errors(
+    call: Callable[[], object],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        call()
+
+
+def test_decision_parsing_helpers_cover_defaults_and_scalar_coercion() -> None:
+    assert decision._list_of_mappings(None, "field") == ()
+    assert decision._optional_string(None) is None
+    assert decision._optional_string("  ") is None
+    assert decision._coerce_float(True, "field") == 1.0
+    assert decision._coerce_float(" 2.5 ", "field") == 2.5
+    assert decision._solve_tridiagonal((), (), (), ()) == ()
+
+
+def _factor(*, part_worths: list[float] | None = None) -> dict[str, object]:
+    return {
+        "key": "factor",
+        "label": "Factor",
+        "levels": [0, 1],
+        "part_worths": [0, 1] if part_worths is None else part_worths,
+    }
+
+
+def _objective(**overrides: object) -> dict[str, object]:
+    values: dict[str, object] = {
+        "key": "utility",
+        "label": "Utility",
+        "sense": "maximize",
+        "domain": "discrete-option",
+        "expression": "factor",
+        "variables": ["factor"],
+        "executable": True,
+    }
+    values.update(overrides)
+    return values
+
+
+def _constraint(**overrides: object) -> dict[str, object]:
+    values: dict[str, object] = {
+        "key": "limit",
+        "label": "Limit",
+        "relation": "<=",
+        "domain": "continuous-design",
+        "expression": "x <= 1",
+        "variables": ["x"],
+        "executable": False,
+    }
+    values.update(overrides)
+    return values
+
+
+def _valid_structured_parameters() -> dict[str, object]:
+    return {
+        "decision_variable_specs": [
+            {"symbol": "x", "label": "X", "lower_bound": 0, "upper_bound": 1},
+        ],
+        "option_factors": [_factor()],
+        "competitor_profiles": [{"name": "baseline", "values": {"factor": 0}}],
+        "objective_specs": [_objective()],
+        "constraint_specs": [_constraint()],
+    }
+
+
+@pytest.mark.parametrize(
+    ("mutator", "message"),
+    [
+        (lambda p: p.update(objective_specs=[_objective(), _objective()]), "Duplicate decision objective"),
+        (lambda p: p.update(objective_specs=[_objective(sense="minimize")]), "must use sense"),
+        (lambda p: p.update(option_factors=[]), "requires option_factors"),
+        (lambda p: p.update(competitor_profiles=[]), "requires competitor_profiles"),
+        (lambda p: p.update(option_factors=[_factor(part_worths=[])]), "requires factor part_worths"),
+        (lambda p: p.update(objective_specs=[_objective(variables=["unknown"])]), "unknown factor keys"),
+        (
+            lambda p: p.update(
+                objective_specs=[_objective(domain="empirical-choice", variables=["material"])],
+            ),
+            "requires choice_options",
+        ),
+        (
+            lambda p: p.update(
+                choice_options=[
+                    {
+                        "key": "steel",
+                        "label": "Steel",
+                        "top_choice_share": 0.5,
+                        "mean_rating": 7,
+                        "median_rating": 7,
+                        "std_rating": 1,
+                    }
+                ],
+                response_count=10,
+                objective_specs=[_objective(domain="empirical-choice", variables=["unknown"])],
+            ),
+            "unknown variables",
+        ),
+        (lambda p: p.update(objective_specs=[_objective(domain="unsupported")]), "must use domain"),
+        (
+            lambda p: p.update(objective_specs=[_objective(executable=False, variables=["unknown"])]),
+            "references unknown variables",
+        ),
+        (lambda p: p.update(constraint_specs=[_constraint(), _constraint()]), "Duplicate decision constraint"),
+        (lambda p: p.update(constraint_specs=[_constraint(variables=["unknown"])]), "references unknown variables"),
+        (lambda p: p.update(option_factors=[], objective_specs=[]), "competitor_profiles require option_factors"),
+        (
+            lambda p: p.update(competitor_profiles=[{"name": "baseline", "values": {"wrong": 0}}]),
+            "must include exactly",
+        ),
+    ],
+)
+def test_structured_decision_payload_rejects_inconsistent_cross_references(
+    mutator: Callable[[dict[str, object]], object],
+    message: str,
+) -> None:
+    parameters = _valid_structured_parameters()
+    mutator(parameters)
+    with pytest.raises(ValueError, match=message):
+        decision.parse_structured_decision_payload(parameters)
+
+
+def test_structured_decision_parsers_reject_duplicate_and_malformed_entries() -> None:
+    variable = {"symbol": "x", "label": "X", "lower_bound": 0, "upper_bound": 1}
+    with pytest.raises(ValueError, match="Duplicate decision variable"):
+        decision._parse_decision_variable_specs({"decision_variable_specs": [variable, variable]})
+    with pytest.raises(ValueError, match="Duplicate option factor"):
+        decision._parse_option_factors({"option_factors": [_factor(), _factor()]})
+
+    choice = {
+        "key": "steel",
+        "label": "Steel",
+        "top_choice_share": 0.5,
+        "mean_rating": 7,
+        "median_rating": 7,
+        "std_rating": 1,
+    }
+    with pytest.raises(ValueError, match="Duplicate choice option key"):
+        decision._parse_choice_benchmarks({"choice_options": [choice, choice]})
+    with pytest.raises(ValueError, match="Duplicate choice option label"):
+        decision._parse_choice_benchmarks({"choice_options": [choice, {**choice, "key": "aluminum", "label": "STEEL"}]})
+    with pytest.raises(ValueError, match="values must be mappings"):
+        decision._parse_competitor_profiles({"competitor_profiles": [{"name": "x", "values": []}]})
+    with pytest.raises(ValueError, match="Duplicate competitor profile"):
+        decision._parse_competitor_profiles(
+            {"competitor_profiles": [{"name": "x", "values": {}}, {"name": "x", "values": {}}]}
+        )
+    with pytest.raises(ValueError, match="Unsupported default_choice_metric"):
+        decision._parse_default_choice_metric({"default_choice_metric": "unknown"}, False)
+    with pytest.raises(ValueError, match="must be positive"):
+        decision._parse_response_count({"response_count": 0}, True)
+    with pytest.raises(ValueError, match="must be non-negative"):
+        decision._parse_response_count({"response_count": -1}, False)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -19,6 +19,25 @@ def test_packaged_problem_id_resolves_to_problem_binding() -> None:
     assert problem.metadata.title in binding.brief
 
 
+def test_resolve_problem_binding_accepts_existing_binding_and_mapping_payload() -> None:
+    class PayloadProblem:
+        problem_id = "payload-problem"
+        family = "optimization"
+        brief = "Payload brief"
+
+    payload_binding = integration.resolve_problem_binding(
+        {"payload": {"problem_object": PayloadProblem()}, "problem_id": "ignored-fallback"}
+    )
+
+    assert payload_binding.problem_id == "payload-problem"
+    assert payload_binding.family == "optimization"
+
+    assert integration.resolve_problem_binding(payload_binding) is payload_binding
+
+    with pytest.raises(ValueError, match="problem_object"):
+        integration.resolve_problem_binding({"payload": {"other": object()}})
+
+
 def test_problem_binding_brief_prefers_render_brief_then_statement_then_metadata() -> None:
     class RenderBriefProblem:
         def __init__(self) -> None:
@@ -42,6 +61,35 @@ def test_problem_binding_brief_prefers_render_brief_then_statement_then_metadata
     assert binding.brief == "# Rendered Brief"
     assert binding.metadata["capabilities"] == ("prompt-packet",)
     assert binding.metadata["study_suitability"] == ("intervention-ready",)
+
+
+def test_problem_binding_brief_falls_back_across_problem_fields() -> None:
+    class TypeErrorBriefProblem:
+        problem_id = "type-error-brief"
+        family = "decision"
+        statement_markdown = "Statement fallback"
+
+        def render_brief(self, _unexpected: object) -> str:
+            return "unreachable"
+
+    class ExceptionBriefProblem:
+        problem_id = "exception-brief"
+        family = "decision"
+        prompt = "Prompt fallback"
+
+        def render_brief(self) -> str:
+            raise RuntimeError("rendering failed")
+
+    class MetadataSummaryProblem:
+        metadata = types.SimpleNamespace(problem_id="", kind=None, summary="Metadata summary", title="Title")
+
+    class MetadataTitleProblem:
+        metadata = types.SimpleNamespace(problem_id="", kind=None, summary="", title="Metadata title")
+
+    assert integration.resolve_problem_binding(TypeErrorBriefProblem()).brief == "Statement fallback"
+    assert integration.resolve_problem_binding(ExceptionBriefProblem()).brief == "Prompt fallback"
+    assert integration.resolve_problem_binding(MetadataSummaryProblem()).brief == "Metadata summary"
+    assert integration.resolve_problem_binding(MetadataTitleProblem()).brief == "Metadata title"
 
 
 def test_evaluate_problem_output_normalizes_dataclass_metrics() -> None:
@@ -80,6 +128,59 @@ def test_evaluate_problem_output_normalizes_dataclass_metrics() -> None:
             "notes_json": {},
         },
     ]
+
+
+def test_evaluate_problem_output_covers_input_selection_and_payload_shapes() -> None:
+    class ShapeProblem:
+        problem_id = "shape"
+        family = "optimization"
+        brief = "brief"
+
+        def __init__(self) -> None:
+            self.inputs: list[object] = []
+
+        def evaluate(self, candidate: object) -> list[object]:
+            self.inputs.append(candidate)
+            return [
+                {"metric_name": "score", "metric_value": 2.5, "metric_unit": "points"},
+                {"secondary": 3, "higher_is_better": True, "ignored": {"nested": "value"}},
+                types.SimpleNamespace(to_dict=lambda: {"tertiary": 4.0}),
+                types.SimpleNamespace(raw=5.0),
+                "not-metrics",
+            ]
+
+    problem = ShapeProblem()
+    binding = integration.resolve_problem_binding(problem)
+    rows = integration.evaluate_problem_output(binding, {"state": {"x": 1}, "candidate": {"x": 0}})
+
+    assert problem.inputs == [{"x": 0}]
+    assert [row["metric_name"] for row in rows] == ["score", "secondary", "tertiary", "raw"]
+    assert rows[0]["metric_value"] == 2.5
+
+    fallback_rows = integration.evaluate_problem_output(binding, {"unstructured": "payload"})
+    assert problem.inputs[-1] == {"unstructured": "payload"}
+    assert fallback_rows
+
+
+def test_evaluate_problem_output_handles_missing_and_invalid_evaluators() -> None:
+    no_evaluator = integration.ProblemBinding(
+        problem_id="none",
+        family="decision",
+        brief="brief",
+        metadata={},
+        problem_object=types.SimpleNamespace(),
+    )
+    assert integration.evaluate_problem_output(no_evaluator, {"answer": "x"}) == []
+
+    invalid_evaluator = integration.ProblemBinding(
+        problem_id="invalid",
+        family="decision",
+        brief="brief",
+        metadata={},
+        problem_object=types.SimpleNamespace(evaluate=42),
+    )
+    with pytest.raises(ValueError, match="callable"):
+        integration.evaluate_problem_output(invalid_evaluator, {"answer": "x"})
 
 
 def test_problem_binding_rejects_non_callable_evaluators() -> None:

--- a/tests/test_mcp_problem_helpers.py
+++ b/tests/test_mcp_problem_helpers.py
@@ -93,6 +93,23 @@ def test_parse_mcp_stdio_parameters_validates_bad_inputs(
         parse_mcp_stdio_parameters(parameters)
 
 
+def test_mcp_subprocess_environment_inherits_parent_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DERP_PARENT_VALUE", "from-parent")
+
+    environment = mcp_problem_module._merged_subprocess_env(
+        {
+            "DERP_CHILD_VALUE": "from-problem",
+            "DERP_PARENT_VALUE": "overridden",
+        }
+    )
+
+    assert environment["DERP_CHILD_VALUE"] == "from-problem"
+    assert environment["DERP_PARENT_VALUE"] == "overridden"
+    assert "PATH" in environment
+
+
 def test_proxy_signature_and_annotation_helpers_cover_schema_edges() -> None:
     signature = _proxy_signature(
         tool_name="echo",

--- a/tests/test_mcp_servers.py
+++ b/tests/test_mcp_servers.py
@@ -117,9 +117,14 @@ def test_optimization_problem_to_mcp_server_exposes_evaluate_and_submit_final(
 
     server = problem.to_mcp_server()
     assert "problem://design-brief" in _resource_uris(server)
-    assert {"evaluate", "submit_final"}.issubset(_tool_names(server))
+    assert {"evaluate", "solver_hints", "submit_final"}.issubset(_tool_names(server))
 
     candidate = problem.generate_initial_solution(seed=3).tolist()
+    hints = _call_tool_json(server, "solver_hints", {})
+    assert hints["variable_domain"] == "continuous"
+    assert hints["equality_constraint_count"] == 1
+    assert hints["recommended_solver_family"] == "constrained continuous optimizer such as SLSQP or trust-constr"
+
     report = _call_tool_json(server, "evaluate", {"x": candidate})
     assert report["evaluation"]["is_feasible"] is True
     assert report["objective_components"]["sum"] == pytest.approx(sum(candidate))

--- a/tests/test_planar_truss_topology_helpers.py
+++ b/tests/test_planar_truss_topology_helpers.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from design_research_problems.problems._domains import planar_truss as planar
+
+
+def test_planar_truss_seed_and_candidate_points_cover_load_layouts() -> None:
+    plain = planar.build_seed_planar_truss_state(10.0, 4.0, 100.0)
+    assert plain.load_joint_id == 2
+    assert plain.additional_loads == ()
+    assert planar.candidate_planar_truss_points(plain) == ((2.5, 2.0), (5.0, 2.0), (7.5, 2.0))
+    assert planar.candidate_planar_truss_points(plain, candidate_point_fractions=((0.2, 0.75),)) == ((2.0, 3.0),)
+
+    roof = planar.build_seed_planar_truss_state(
+        10.0,
+        4.0,
+        120.0,
+        roof_load_x_fractions=(0.25, 0.5, 0.75),
+        enforce_symmetry=True,
+    )
+    assert roof.symmetry_axis_x == 5.0
+    assert roof.load_vector == (0.0, -40.0, 0.0)
+    assert len(roof.additional_loads) == 2
+
+
+def test_planar_truss_candidate_expansion_handles_plain_and_symmetric_states() -> None:
+    plain = planar.build_seed_planar_truss_state(10.0, 4.0, 100.0)
+    expanded = planar.expand_planar_truss_candidate_joints(
+        plain,
+        ((2.5, 2.0), (2.5, 2.0), (5.0, 4.0)),
+    )
+    assert len(expanded.joints) == len(plain.joints) + 1
+
+    symmetric = replace(plain, symmetry_axis_x=5.0)
+    expanded_symmetric = planar.expand_planar_truss_candidate_joints(
+        symmetric,
+        ((2.5, 2.0), (7.5, 2.0), (5.0, 1.0), (5.0, 4.0)),
+    )
+    coordinates = {(joint.x, joint.y) for joint in expanded_symmetric.joints}
+    assert {(2.5, 2.0), (7.5, 2.0), (5.0, 1.0)} <= coordinates
+
+    assert planar.mirrored_joint_id(plain, 999) == 999
+    assert planar.mirrored_joint_id(symmetric, 999) is None
+    incomplete = replace(symmetric, joints=tuple(joint for joint in symmetric.joints if joint.joint_id != 1))
+    assert planar.mirrored_joint_id(incomplete, 0) is None
+    assert planar.mirrored_edge(incomplete, (0, 2)) is None
+
+
+def test_planar_truss_edge_enumeration_and_state_building_enforce_symmetry() -> None:
+    seed = planar.build_seed_planar_truss_state(10.0, 4.0, 100.0, enforce_symmetry=True)
+    expanded = planar.expand_planar_truss_candidate_joints(seed, ((2.5, 2.0), (5.0, 1.0)))
+    candidates = planar.enumerate_planar_truss_candidate_edges(expanded)
+    assert candidates
+    assert len(candidates) == len(set(candidates))
+
+    built = planar.build_planar_truss_state_from_edges(expanded, (candidates[0],))
+    assert built.members
+    assert all(member.start_joint_id < member.end_joint_id for member in built.members)
+
+    with pytest.raises(ValueError, match="existing joints"):
+        planar.build_planar_truss_state_from_edges(expanded, ((0, 999),))
+
+    asymmetric = replace(
+        expanded,
+        joints=tuple(joint for joint in expanded.joints if not (joint.x == 7.5 and joint.y == 2.0)),
+    )
+    with pytest.raises(ValueError, match="mirrored joints"):
+        planar.build_planar_truss_state_from_edges(asymmetric, ((0, 3),))
+
+
+def test_planar_truss_state_builder_retains_preexisting_members_and_loaded_joints() -> None:
+    seed = planar.build_seed_planar_truss_state(
+        10.0,
+        4.0,
+        100.0,
+        roof_load_x_fractions=(0.25, 0.75),
+    )
+    with_member = replace(seed, members=(planar.PlanarMember(member_id=7, start_joint_id=0, end_joint_id=2),))
+    built = planar.build_planar_truss_state_from_edges(with_member, ((1, 3),))
+    assert {planar.edge_key(member.start_joint_id, member.end_joint_id) for member in built.members} == {
+        (0, 2),
+        (1, 3),
+    }
+    assert {joint.joint_id for joint in built.joints} == {0, 1, 2, 3}

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -12,6 +12,7 @@ EXPECTED_PUBLIC_API = [
     "ComputableProblem",
     "ProblemKind",
     "ProblemMetadata",
+    "ProblemCatalogSummary",
     "ProblemTaxonomy",
     "Citation",
     "ProblemAsset",
@@ -35,6 +36,7 @@ EXPECTED_PUBLIC_API = [
     "get_problem",
     "get_problem_as",
     "list_problems",
+    "search_problem_summaries",
     "get_ideation_catalog",
     "integration",
 ]

--- a/tests/test_registry_and_problems.py
+++ b/tests/test_registry_and_problems.py
@@ -22,10 +22,12 @@ from design_research_problems import (
     OptimizationEvaluation,
     OptimizationProblem,
     Problem,
+    ProblemCatalogSummary,
     ProblemEvaluationError,
     ProblemKind,
     get_problem,
     list_problems,
+    search_problem_summaries,
 )
 from design_research_problems.problems import DecisionOption
 from design_research_problems.problems._domains.battery_cell_model import BatteryBackendConfig, BatteryCellModel
@@ -458,6 +460,28 @@ def test_registry_search_filters_by_feature_flags() -> None:
         "ideation_remote_village_rainwater_access",
         "ideation_snow_transport_for_novices",
     ]
+
+
+def test_registry_exposes_compact_problem_summaries_for_agent_selection() -> None:
+    from design_research_problems import ProblemRegistry
+
+    registry = ProblemRegistry()
+    summaries = registry.summaries(text="pill", kind=ProblemKind.OPTIMIZATION)
+
+    assert summaries
+    assert all(isinstance(summary, ProblemCatalogSummary) for summary in summaries)
+    pill_summary = next(summary for summary in summaries if summary.problem_id == "pill_capsule_min_area")
+    assert pill_summary.kind is ProblemKind.OPTIMIZATION
+    assert pill_summary.design_variable_type == "continuous"
+    assert pill_summary.bounds_summary == "radius and length bounded on [0, 1]"
+    assert "baseline-solver" in pill_summary.capabilities
+    assert pill_summary.to_dict()["kind"] == "optimization"
+    assert "statement" not in pill_summary.to_dict()
+
+    top_level_summaries = search_problem_summaries(text="peanut", kind="text")
+    top_level_ids = [summary.problem_id for summary in top_level_summaries]
+    assert "ideation_peanut_shelling" in top_level_ids
+    assert "ideation_peanut_shelling_fu_cagan_kotovsky_2010" in top_level_ids
 
 
 def test_pill_helpers_return_expected_positive_values() -> None:
@@ -939,6 +963,21 @@ def test_pill_problem_evaluate_returns_standardized_optimization_evaluation() ->
     assert evaluation.total_constraint_violation == pytest.approx(problem.constraint_violation(candidate))
     assert evaluation.max_constraint_violation == pytest.approx(problem.max_constraint_violation(candidate))
     assert evaluation.is_feasible is True
+
+
+def test_pill_problem_exposes_solver_hints_without_parsing_brief_prose() -> None:
+    problem = get_problem("pill_capsule_min_area")
+    hints = problem.solver_hints()
+
+    assert hints["problem_id"] == "pill_capsule_min_area"
+    assert hints["problem_kind"] == "optimization"
+    assert hints["variable_count"] == 2
+    assert hints["variable_domain"] == "continuous"
+    assert hints["lower_bounds"] == [0.0, 0.0]
+    assert hints["upper_bounds"] == [1.0, 1.0]
+    assert hints["equality_constraint_count"] == 1
+    assert hints["inequality_constraint_count"] == 0
+    assert hints["recommended_solver_family"] == "constrained continuous optimizer such as SLSQP or trust-constr"
 
 
 def test_pill_problem_seeded_initial_solution_stays_within_bounds() -> None:

--- a/tests/test_truss_ap_problem.py
+++ b/tests/test_truss_ap_problem.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from dataclasses import replace
 from pathlib import Path
 from typing import Any
@@ -8,6 +9,7 @@ from typing import Any
 import pytest
 
 from design_research_problems import GrammarProblem, get_problem, list_problems
+from design_research_problems.problems._domains import truss_ap as truss_domain
 from design_research_problems.problems._domains.truss_ap import (
     TrussAPJoint,
     TrussAPLoad,
@@ -171,3 +173,155 @@ def test_truss_analysis_program_top_node_fan_with_bottom_chain_is_stable() -> No
     assert evaluation.is_stable
     assert evaluation.failure_reason is None
     assert len(evaluation.fos_by_member) == len(state.members)
+
+
+def test_truss_geometry_helpers_cover_boundary_intersection_cases() -> None:
+    square = ((0.0, 0.0), (2.0, 0.0), (2.0, 2.0), (0.0, 2.0))
+    assert truss_domain._point_in_polygon(1.0, 1.0, square)
+    assert truss_domain._point_in_polygon(0.0, 1.0, square)
+    assert not truss_domain._point_in_polygon(3.0, 1.0, square)
+
+    assert truss_domain._segments_intersect(0, 0, 2, 2, 0, 2, 2, 0)
+    assert truss_domain._segments_intersect(0, 0, 2, 0, 1, 0, 3, 0)
+    assert truss_domain._segments_intersect(0, 0, 2, 0, 2, 0, 3, 1)
+    assert truss_domain._segments_intersect(1, 0, 3, 0, 0, 0, 2, 0)
+    assert truss_domain._segments_intersect(0, 0, 2, 0, 3, 0, 2, 0)
+    assert not truss_domain._segments_intersect(0, 0, 1, 0, 0, 1, 1, 1)
+
+    assert truss_domain._segment_intersects_polygon((1, 1), (3, 3), square)
+    assert truss_domain._segment_intersects_polygon((-1, 1), (3, 1), square)
+    assert not truss_domain._segment_intersects_polygon((-2, -2), (-1, -1), square)
+
+
+@pytest.mark.parametrize(
+    ("mutator", "message"),
+    [
+        (lambda state: replace(state, required_support_joint_ids=(1, 2)), "Exactly three"),
+        (lambda state: replace(state, support_enabled=(True,)), "support_enabled length"),
+        (
+            lambda state: replace(state, loads=(TrussAPLoad(joint_id=999, direction="down", magnitude_n=1),)),
+            "Loads must reference",
+        ),
+        (
+            lambda state: replace(state, loads=(TrussAPLoad(joint_id=1, direction="down", magnitude_n=float("inf")),)),
+            "magnitudes must be finite",
+        ),
+        (
+            lambda state: replace(
+                state,
+                members=(TrussAPMember(member_id=1, start_joint_id=1, end_joint_id=1, size_index=1),),
+            ),
+            "cannot connect a joint to itself",
+        ),
+        (
+            lambda state: replace(
+                state,
+                members=(TrussAPMember(member_id=1, start_joint_id=1, end_joint_id=999, size_index=1),),
+            ),
+            "reference existing joints",
+        ),
+        (
+            lambda state: replace(
+                state,
+                members=(TrussAPMember(member_id=1, start_joint_id=1, end_joint_id=2, size_index=0),),
+            ),
+            "size index is out of bounds",
+        ),
+        (
+            lambda state: replace(
+                state,
+                size_index_max=99,
+                members=(TrussAPMember(member_id=1, start_joint_id=1, end_joint_id=2, size_index=11),),
+            ),
+            "exceeds the available section table",
+        ),
+        (
+            lambda state: replace(
+                state,
+                members=(
+                    TrussAPMember(member_id=1, start_joint_id=1, end_joint_id=2, size_index=1),
+                    TrussAPMember(member_id=2, start_joint_id=2, end_joint_id=1, size_index=1),
+                ),
+            ),
+            "Duplicate members",
+        ),
+    ],
+)
+def test_truss_state_validation_reports_malformed_fields(
+    mutator: Callable[[TrussAPState], TrussAPState],
+    message: str,
+) -> None:
+    state = mutator(truss_domain.build_default_truss_ap_state())
+    evaluation = truss_domain.evaluate_truss_ap_state(state)
+    assert evaluation.failure_reason is not None
+    assert message in evaluation.failure_reason
+
+
+def test_truss_grammar_enumerates_and_applies_the_full_editing_workflow() -> None:
+    problem = get_problem("truss_analysis_program_design")
+    state = problem.initial_state()
+    assert {transition.rule_name for transition in problem.enumerate_transitions(state)} >= {
+        "add_joint",
+        "add_member",
+        "set_support_enabled",
+        "set_load",
+        "clear_load",
+    }
+
+    state = problem.add_joint(state, x=-3.446939, y=1.847708)
+    editable_id = max(joint.joint_id for joint in state.joints)
+    moved = problem.move_joint(state, joint_id=editable_id, x=-2.0, y=2.0)
+    with pytest.raises(ValueError, match="Unknown joint"):
+        problem.move_joint(state, joint_id=999, x=0, y=0)
+    with pytest.raises(ValueError, match="Fixed joints"):
+        problem.move_joint(state, joint_id=1, x=0, y=0)
+    with pytest.raises(ValueError, match="design bounds"):
+        problem.move_joint(state, joint_id=editable_id, x=999, y=999)
+    with pytest.raises(ValueError, match="already exists"):
+        problem.move_joint(state, joint_id=editable_id, x=-5.0, y=0.0)
+
+    state = problem.add_member(moved, start_joint_id=1, end_joint_id=editable_id, size_index=5)
+    member_id = state.members[-1].member_id
+    assert {transition.rule_name for transition in problem.enumerate_transitions(state)} >= {
+        "move_joint",
+        "delete_joint",
+        "delete_member",
+        "set_member_size",
+    }
+    with pytest.raises(ValueError, match="itself"):
+        problem.add_member(state, start_joint_id=1, end_joint_id=1, size_index=5)
+    with pytest.raises(ValueError, match="existing joints"):
+        problem.add_member(state, start_joint_id=1, end_joint_id=999, size_index=5)
+    with pytest.raises(ValueError, match="already exists"):
+        problem.add_member(state, start_joint_id=editable_id, end_joint_id=1, size_index=5)
+    with pytest.raises(ValueError, match="out of bounds"):
+        problem.add_member(state, start_joint_id=2, end_joint_id=editable_id, size_index=99)
+    with pytest.raises(ValueError, match="Unknown member"):
+        problem.delete_member(state, member_id=999)
+    with pytest.raises(ValueError, match="out of bounds"):
+        problem.set_member_size(state, member_id=member_id, size_index=99)
+    with pytest.raises(ValueError, match="Unknown member"):
+        problem.set_member_size(state, member_id=999, size_index=5)
+    resized = problem.set_member_size(state, member_id=member_id, size_index=6)
+    assert resized.members[-1].size_index == 6
+
+    with pytest.raises(ValueError, match="support_id"):
+        problem.set_support_enabled(state, support_id=0, enabled=False)
+    assert problem.set_support_enabled(state, support_id=1, enabled=False).support_enabled[0] is False
+    with pytest.raises(ValueError, match="Unknown joint"):
+        problem.set_load(state, joint_id=999, direction="down", magnitude_n=50_000)
+    with pytest.raises(ValueError, match="direction"):
+        problem.set_load(state, joint_id=1, direction="bad", magnitude_n=50_000)
+    with pytest.raises(ValueError, match="Unsupported load"):
+        problem.set_load(state, joint_id=1, direction="down", magnitude_n=1)
+    loaded = problem.set_load(state, joint_id=1, direction="left", magnitude_n=50_000)
+    with pytest.raises(ValueError, match="Unknown joint"):
+        problem.clear_load(loaded, joint_id=999, direction="left")
+    with pytest.raises(ValueError, match="direction"):
+        problem.clear_load(loaded, joint_id=1, direction="bad")
+    assert len(problem.clear_load(loaded, joint_id=1, direction="left").loads) < len(loaded.loads)
+
+    deleted = problem.delete_member(state, member_id=member_id)
+    assert len(deleted.members) == len(state.members) - 1
+    without_joint = problem.delete_joint(state, joint_id=editable_id)
+    assert all(joint.joint_id != editable_id for joint in without_joint.joints)

--- a/tests/test_typing_surface.py
+++ b/tests/test_typing_surface.py
@@ -1,0 +1,37 @@
+"""Consumer-level checks for the advertised typed package surface."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from mypy import api as mypy_api
+
+
+def test_lazy_top_level_exports_keep_concrete_types(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Type-check representative imports as a downstream package would."""
+    source = tmp_path / "consumer.py"
+    source.write_text(
+        """\
+from collections.abc import Callable
+
+from design_research_problems import Problem, ProblemCatalogSummary, search_problem_summaries
+
+
+def accepts_problem(problem: Problem, summary: ProblemCatalogSummary) -> None:
+    pass
+
+
+search: Callable[..., tuple[ProblemCatalogSummary, ...]] = search_problem_summaries
+""",
+        encoding="utf-8",
+    )
+    package_src = Path(__file__).resolve().parents[1] / "src"
+    monkeypatch.setenv("MYPYPATH", str(package_src))
+
+    stdout, stderr, status = mypy_api.run(["--strict", "--no-incremental", str(source)])
+
+    assert status == 0, stdout + stderr

--- a/tests/test_ui_and_problem_utilities.py
+++ b/tests/test_ui_and_problem_utilities.py
@@ -191,12 +191,13 @@ def test_problem_helpers_mcp_json_optional_and_assets_cover_edge_paths(
     monkeypatch.setattr(problem_module, "create_fastmcp_server", lambda *args, **kwargs: fake_server)
     monkeypatch.setattr(problem_module, "register_design_brief_resource", lambda *args, **kwargs: None)
 
-    problem = Problem(metadata=_metadata(), statement_markdown="# Different Title")
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
-        assert problem._starts_with_h1("# Different Title") is True
+        mismatched_problem = Problem(metadata=_metadata(), statement_markdown="# Different Title")
+        assert mismatched_problem._starts_with_h1("# Different Title") is True
     assert any("does not match metadata title" in str(warning.message) for warning in caught)
 
+    problem = Problem(metadata=_metadata(), statement_markdown="# Utility Problem")
     server = problem.to_mcp_server()
     submit_func = next(func for func, kwargs in server.tools if kwargs["name"] == "submit_final")
     with pytest.raises(ValueError, match="non-empty string"):
@@ -288,7 +289,8 @@ def test_gui_helpers_cover_lazy_exports_launcher_and_layout(monkeypatch: pytest.
     monkeypatch.setitem(sys.modules, "design_research_problems.gui.iot_home_cooling_tk", app_module)
     monkeypatch.setattr(sys, "argv", ["launcher", "--app", "iot"])
 
-    runpy.run_module("design_research_problems.gui._launcher", run_name="__main__")
+    with pytest.warns(RuntimeWarning, match="found in sys.modules"):
+        runpy.run_module("design_research_problems.gui._launcher", run_name="__main__")
 
     assert ("geometry", "1250x760") in launcher_events
     assert any(event[0] == "mainloop" for event in launcher_events)


### PR DESCRIPTION
## Summary

- add compact catalog summaries and search for choosing problems without loading full objects
- add solver hints for optimization problems and expose them through MCP
- salvage the focused integration work from #81 without carrying its private-edge coverage file
- inherit the parent environment for MCP subprocesses while allowing problem-specific overrides
- preserve concrete downstream types across the lazy top-level API and packaged forwarding stub
- remove shadowed battery grammar/optimizer implementations and redundant validation branches
- add deterministic contract tests for decision parsing, truss editing, Build123d, battery fitting, and direct PyBaMM adapters
- exercise the Build123d primitive protocol without requiring the optional CAD package in the default suite
- require at least 95% line coverage and 100% of curated top-level exports in runnable examples
- bump the package from 0.3.0 to 0.4.0

## Why

This consolidates the durable work from #81 and #83 into one release candidate without reviving monthly milestone machinery. The minor version reflects the new public catalog and solver-hint API.

The MCP environment fix prevents a configured `env` mapping from accidentally dropping `PATH`, credentials, and inherited process settings. The typing change makes the existing `Typing :: Typed` classifier accurate for lazy package exports.

The battery cleanup keeps behavior in concrete registered tier implementations and replaces slow optional-solver dependence in the default suite with deterministic adapter contracts. The Build123d protocol double makes the same coverage guarantee on Linux and macOS while retaining the real optional-backend integration test.

## Validation

- full deterministic test suite and `make coverage`
- 95.04% total line coverage on GitHub's Python 3.12 runner
- API in Examples: 32/32; examples passing: 36/36
- `make lint fmt-check type docstrings-check docs-check`
- warning-free Sphinx HTML build across 256 source pages
- `make release-check`; sdist and wheel pass `twine check`
- built wheel contains `py.typed` and `design_research_problems/__init__.pyi`

## Release Safety

- GitHub Releases publish only when the release tag matches the package version.
- Manual workflow runs are build-only unless publishing is explicitly enabled from the matching tag.
- All publishing paths run `make release-check` before PyPI upload.
